### PR TITLE
Adding "Clean-sky" Diagnostics into MPAS-A

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-MPAS-v8.3.1-2.1
+MPAS-v8.3.0-2.0
 ====
 
 The Model for Prediction Across Scales (MPAS) is a collaborative project for

--- a/list_of_module
+++ b/list_of_module
@@ -1,0 +1,10 @@
+
+Currently Loaded Modules:
+  1) stack-intel/2021.5.0   6) gnu/14.2.0      11) hdf5parallel/1.10.6
+  2) nghttp2/1.57.0         7) intel/2022.1.2  12) netcdf-hdf5parallel/4.7.4
+  3) zlib/1.2.13            8) impi/2022.1.2   13) rrfs/jet.intel
+  4) curl/8.4.0             9) pnetcdf/1.7.0
+  5) cmake/3.23.1          10) szip/2.1
+
+ 
+

--- a/src/core_atmosphere/Externals.cfg
+++ b/src/core_atmosphere/Externals.cfg
@@ -2,7 +2,7 @@
 local_path = ./physics_mmm
 protocol = git
 repo_url = https://github.com/NCAR/MMM-physics.git
-tag = 20250616-MPASv8.3
+tag = 20240626-MPASv8.2
 required = True
 
 [GSL_UGWP]

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<registry model="mpas" core="atmosphere" core_abbrev="atm" version="8.3.1-2.1">
+<registry model="mpas" core="atmosphere" core_abbrev="atm" version="8.3.0-2.0">
 
 <!-- **************************************************************************************** -->
 <!-- ************************************** Dimensions ************************************** -->
@@ -772,37 +772,53 @@
 			<var name="rvbldiff"/>
 			<var name="i_acswdnb"/>
 			<var name="i_acswdnbc"/>
+			<var name="i_acswdnbcln"/>
 			<var name="i_acswdnt"/>
 			<var name="i_acswdntc"/>
+			<var name="i_acswdntcln"/>
 			<var name="i_acswupb"/>
 			<var name="i_acswupbc"/>
+			<var name="i_acswupbcln"/>
 			<var name="i_acswupt"/>
 			<var name="i_acswuptc"/>
+			<var name="i_acswuptcln"/>
 			<var name="acswdnb"/>
 			<var name="acswdnbc"/>
+			<var name="acswdnbcln"/>
 			<var name="acswdnt"/>
 			<var name="acswdntc"/>
+			<var name="acswdntcln"/>
 			<var name="acswupb"/>
 			<var name="acswupbc"/>
+			<var name="acswupbcln"/>
 			<var name="acswupt"/>
 			<var name="acswuptc"/>
+			<var name="acswuptcln"/>
 			<var name="gsw"/>
 			<var name="i_aclwdnb"/>
 			<var name="i_aclwdnbc"/>
+			<var name="i_aclwdnbcln"/>
 			<var name="i_aclwdnt"/>
 			<var name="i_aclwdntc"/>
+			<var name="i_aclwdntcln"/>
 			<var name="i_aclwupb"/>
 			<var name="i_aclwupbc"/>
+			<var name="i_aclwupbcln"/>
 			<var name="i_aclwupt"/>
 			<var name="i_aclwuptc"/>
+			<var name="i_aclwuptcln"/>
 			<var name="aclwdnb"/>
 			<var name="aclwdnbc"/>
+			<var name="aclwdnbcln"/>
 			<var name="aclwdnt"/>
 			<var name="aclwdntc"/>
+			<var name="aclwdntcln"/>
 			<var name="aclwupb"/>
 			<var name="aclwupbc"/>
+			<var name="aclwupbcln"/>
 			<var name="aclwupt"/>
 			<var name="aclwuptc"/>
+			<var name="aclwuptcln"/>
 			<var name="glw"/>
 			<var name="o3clim"/>
 			<var name="o3vmr"/>
@@ -883,6 +899,7 @@
 			<var name="rnwfablten"/>
 			<var name="rthratensw"/>
 			<var name="rthratenlw"/>
+			<var name="rthratenlwc"/>
 			<var name="vcpool" packages="cu_grell_freitas_li_in"/>
                         <var name="sub3d_rthcuten" packages="cu_grell_freitas_li_in"/>
                         <var name="sub3d_rqvcuten" packages="cu_grell_freitas_li_in"/>
@@ -1503,37 +1520,53 @@
                         <var name="rvbldiff"/>
                         <var name="i_acswdnb"/>
                         <var name="i_acswdnbc"/>
+                        <var name="i_acswdnbcln"/>
                         <var name="i_acswdnt"/>
                         <var name="i_acswdntc"/>
+                        <var name="i_acswdntcln"/>
                         <var name="i_acswupb"/>
                         <var name="i_acswupbc"/>
+                        <var name="i_acswupbcln"/>
                         <var name="i_acswupt"/>
                         <var name="i_acswuptc"/>
+                        <var name="i_acswuptcln"/>
                         <var name="acswdnb"/>
                         <var name="acswdnbc"/>
+                        <var name="acswdnbcln"/>
                         <var name="acswdnt"/>
                         <var name="acswdntc"/>
+                        <var name="acswdntcln"/>
                         <var name="acswupb"/>
                         <var name="acswupbc"/>
+                        <var name="acswupbcln"/>
                         <var name="acswupt"/>
                         <var name="acswuptc"/>
+                        <var name="acswuptcln"/>
                         <var name="gsw"/>
                         <var name="i_aclwdnb"/>
                         <var name="i_aclwdnbc"/>
+                        <var name="i_aclwdnbcln"/>
                         <var name="i_aclwdnt"/>
                         <var name="i_aclwdntc"/>
+                        <var name="i_aclwdntcln"/>
                         <var name="i_aclwupb"/>
                         <var name="i_aclwupbc"/>
+                        <var name="i_aclwupbcln"/>
                         <var name="i_aclwupt"/>
                         <var name="i_aclwuptc"/>
+                        <var name="i_aclwuptcln"/>
                         <var name="aclwdnb"/>
                         <var name="aclwdnbc"/>
+                        <var name="aclwdnbcln"/>
                         <var name="aclwdnt"/>
-                        <var name="aclwdntc"/>
+			<var name="aclwdntc"/>
+                        <var name="aclwdntcln"/>
                         <var name="aclwupb"/>
                         <var name="aclwupbc"/>
+                        <var name="aclwupbcln"/>
                         <var name="aclwupt"/>
                         <var name="aclwuptc"/>
+                        <var name="aclwuptcln"/>
                         <var name="glw"/>
                         <var name="o3clim"/>
                         <var name="o3vmr"/>
@@ -1606,6 +1639,7 @@
                         <var name="rnwfablten"/>
                         <var name="rthratensw"/>
                         <var name="rthratenlw"/>
+                        <var name="rthratenlwc"/>
                         <var name="vcpool" packages="cu_grell_freitas_in"/>
                         <var name="sub3d_rthcuten" packages="cu_grell_freitas_in"/>
                         <var name="sub3d_rqvcuten" packages="cu_grell_freitas_in"/>
@@ -2680,6 +2714,11 @@
                      units="-"
                      description="logical for configuration of sea-surface temperature"
                      possible_values=".true. for time-varying sea-surface temperatures; .false., otherwise"/>
+
+                <nml_option name="config_calc_clean_atm_diag" type="logical" default_value="false"
+                     units="-"
+                     description="logical for clean sky diagnostics"
+		     possible_values=".true. for clean sky/clear sky calculation; .false., otherwise"/>
 
 	        <nml_option name="config_gvf_update" type="logical" default_value="true"
                      units="-"
@@ -3762,11 +3801,17 @@
                 <var name="i_acswdnbc" type="integer" dimensions="nCells Time" units="unitless"
                      description="incidence of accumulated clear-sky downward surface shortwave radiation greater than config_bucket_radt"/>
 
+                <var name="i_acswdnbcln" type="integer" dimensions="nCells Time" units="unitless"
+                     description="incidence of accumulated clean-sky downward surface shortwave radiation greater than config_bucket_radt"/>
+
                 <var name="i_acswdnt" type="integer" dimensions="nCells Time" units="unitless"
                      description="incidence of accumulated all-sky downward top-of-atmosphere shortwave radiation greater than config_bucket_radt"/>
 
                 <var name="i_acswdntc" type="integer" dimensions="nCells Time" units="unitless"
                      description="incidence of accumulated clear-sky downward top-of-atmosphere shortwave radiation greater than config_bucket_radt"/>
+
+                <var name="i_acswdntcln" type="integer" dimensions="nCells Time" units="unitless"
+                     description="incidence of accumulated clean-sky downward top-of-atmosphere shortwave radiation greater than config_bucket_radt"/>
 
                 <var name="i_acswupb" type="integer" dimensions="nCells Time" units="unitless"
                      description="incidence of accumulated all-sky upward surface shortwave radiation greater than config_bucket_radt"/>
@@ -3774,11 +3819,17 @@
                 <var name="i_acswupbc" type="integer" dimensions="nCells Time" units="unitless"
                      description="incidence of accumulated clear-sky upward surface shortwave radiation greater than config_bucket_radt"/>
 
+                <var name="i_acswupbcln" type="integer" dimensions="nCells Time" units="unitless"
+                     description="incidence of accumulated clean-sky upward surface shortwave radiation greater than config_bucket_radt"/>
+
                 <var name="i_acswupt" type="integer" dimensions="nCells Time" units="unitless"
                      description="incidence of accumulated all-sky upward top-of-atmosphere shortwave radiation greater than config_bucket_radt"/>
 
                 <var name="i_acswuptc" type="integer" dimensions="nCells Time" units="unitless"
                      description="incidence of accumulated clear-sky upward top-of-atmosphere shortwave radiation greater than config_bucket_radt"/>
+
+                <var name="i_acswuptcln" type="integer" dimensions="nCells Time" units="unitless"
+                     description="incidence of accumulated clean-sky upward top-of-atmosphere shortwave radiation greater than config_bucket_radt"/>
 
                 <var name="coszr" type="real" dimensions="nCells Time" units="unitless"
                      description="cosine of zenith solar angle"/>
@@ -3792,11 +3843,17 @@
                 <var name="swdnbc" type="real" dimensions="nCells Time" units="W m^{-2}"
                      description="clear-sky downward surface shortwave radiation flux"/>
 
+                <var name="swdnbcln" type="real" dimensions="nCells Time" units="W m^{-2}"
+                     description="clean-sky downward surface shortwave radiation flux"/>
+
                 <var name="swdnt" type="real" dimensions="nCells Time" units="W m^{-2}"
                      description="all-sky downward top-of-atmosphere shortwave radiation flux"/>
 
                 <var name="swdntc" type="real" dimensions="nCells Time" units="W m^{-2}"
                      description="clear-sky downward top-of-atmosphere shortwave radiation flux"/>
+
+                <var name="swdntcln" type="real" dimensions="nCells Time" units="W m^{-2}"
+                     description="clean-sky downward top-of-atmosphere shortwave radiation flux"/>
 
                 <var name="swupb" type="real" dimensions="nCells Time" units="W m^{-2}"
                      description="all-sky upward surface shortwave radiation flux"/>
@@ -3804,11 +3861,17 @@
                 <var name="swupbc" type="real" dimensions="nCells Time" units="W m^{-2}"
                      description="clear-sky upward surface shortwave radiation flux"/>
 
+                <var name="swupbcln" type="real" dimensions="nCells Time" units="W m^{-2}"
+                     description="clean-sky upward surface shortwave radiation flux"/>
+
                 <var name="swupt" type="real" dimensions="nCells Time" units="W m^{-2}"
                      description="all-sky upward top-of-atmosphere shortwave radiation flux"/>
 
                 <var name="swuptc" type="real" dimensions="nCells Time" units="W m^{-2}"
                      description="clear-sky upward top-of-atmosphere shortwave radiation flux"/>
+
+                <var name="swuptcln" type="real" dimensions="nCells Time" units="W m^{-2}"
+                     description="clean-sky upward top-of-atmosphere shortwave radiation flux"/>
 
                 <var name="acswdnb" type="real" dimensions="nCells Time" units="W m^{-2}"
                      description="accumulated all-sky downward surface shortwave radiation flux"/>
@@ -3816,11 +3879,17 @@
                 <var name="acswdnbc" type="real" dimensions="nCells Time" units="W m^{-2}"
                      description="accumulated clear-sky downward surface shortwave radiation flux"/>
 
+                <var name="acswdnbcln" type="real" dimensions="nCells Time" units="W m^{-2}"
+                     description="accumulated clean-sky downward surface shortwave radiation flux"/>
+
                 <var name="acswdnt" type="real" dimensions="nCells Time" units="W m^{-2}"
                      description="accumulated all-sky downward top-of-atmosphere shortwave radiation flux"/>
 
                 <var name="acswdntc" type="real" dimensions="nCells Time" units="W m^{-2}"
                      description="accumulated clear-sky downward top-of-atmosphere shortwave radiation flux"/>
+
+                <var name="acswdntcln" type="real" dimensions="nCells Time" units="W m^{-2}"
+                     description="accumulated clean-sky downward top-of-atmosphere shortwave radiation flux"/>
 
                 <var name="acswupb" type="real" dimensions="nCells Time" units="W m^{-2}"
                      description="accumulated all-sky upward surface shortwave radiation flux"/>
@@ -3828,11 +3897,17 @@
                 <var name="acswupbc" type="real" dimensions="nCells Time" units="W m^{-2}"
                      description="accumulated clear-sky upward surface shortwave radiation flux"/>
 
+                <var name="acswupbcln" type="real" dimensions="nCells Time" units="W m^{-2}"
+                     description="accumulated clean-sky upward surface shortwave radiation flux"/>
+
                 <var name="acswupt" type="real" dimensions="nCells Time" units="W m^{-2}"
                      description="accumulated all-sky upward top-of-atmosphere shortwave radiation flux"/>
 
                 <var name="acswuptc" type="real" dimensions="nCells Time" units="W m^{-2}"
                      description="accumulated clear-sky upward top-of-atmosphere shortwave radiation flux"/>
+
+                <var name="acswuptcln" type="real" dimensions="nCells Time" units="W m^{-2}"
+                     description="accumulated clean-sky upward top-of-atmosphere shortwave radiation flux"/>
 
                 <var name="swddir" type="real" dimensions="nCells Time" units="W m^{-2}"
                      description="shortwave surface downward direct irradiance"/>
@@ -3853,10 +3928,16 @@
                 <var name="swdnflxc" type="real" dimensions="nVertLevelsP2 nCells Time" units="-"
                      description="-"/>
 
+                <var name="swdnflxcln" type="real" dimensions="nVertLevelsP2 nCells Time" units="-"
+                     description="-"/>
+
                 <var name="swupflx" type="real" dimensions="nVertLevelsP2 nCells Time" units="-"
                      description="-"/>
 
                 <var name="swupflxc" type="real" dimensions="nVertLevelsP2 nCells Time" units="-"
+                     description="-"/>
+
+                <var name="swupflxcln" type="real" dimensions="nVertLevelsP2 nCells Time" units="-"
                      description="-"/>
 
 
@@ -3876,11 +3957,17 @@
                 <var name="i_aclwdnbc" type="integer" dimensions="nCells Time" units="unitless"
                      description="incidence of accumulated clear-sky downward surface longwave radiation greater than config_bucket_radt"/>
 
+                <var name="i_aclwdnbcln" type="integer" dimensions="nCells Time" units="unitless"
+                     description="incidence of accumulated clean-sky downward surface longwave radiation greater than config_bucket_radt"/>
+
                 <var name="i_aclwdnt" type="integer" dimensions="nCells Time" units="unitless"
                      description="incidence of accumulated all-sky downward top-of-atmosphere longwave radiation greater than config_bucket_radt"/>
 
                 <var name="i_aclwdntc" type="integer" dimensions="nCells Time" units="unitless"
                      description="incidence of accumulated clear-sky downward top-of-atmosphere longwave radiation greater than config_bucket_radt"/>
+
+                <var name="i_aclwdntcln" type="integer" dimensions="nCells Time" units="unitless"
+                     description="incidence of accumulated clean-sky downward top-of-atmosphere longwave radiation greater than config_bucket_radt"/>
 
                 <var name="i_aclwupb"  type="integer" dimensions="nCells Time" units="unitless"
                      description="incidence of accumulated all-sky upward surface longwave radiation greater than config_bucket_radt"/>
@@ -3888,11 +3975,17 @@
                 <var name="i_aclwupbc" type="integer" dimensions="nCells Time" units="unitless"
                      description="incidence of accumulated clear-sky upward surface longwave radiation greater than config_bucket_radt"/>
 
+                <var name="i_aclwupbcln" type="integer" dimensions="nCells Time" units="unitless"
+                     description="incidence of accumulated clean-sky upward surface longwave radiation greater than config_bucket_radt"/>
+
                 <var name="i_aclwupt" type="integer" dimensions="nCells Time" units="unitless"
                      description="incidence of accumulated all-sky upward top-of-atmosphere longwave radiation greater than config_bucket_radt"/>
 
                 <var name="i_aclwuptc" type="integer" dimensions="nCells Time" units="unitless"
                      description="incidence of accumulated clear-sky upward top-of-atmosphere longwave radiation greater than config_bucket_radt"/>
+
+                <var name="i_aclwuptcln" type="integer" dimensions="nCells Time" units="unitless"
+                     description="incidence of accumulated clean-sky upward top-of-atmosphere longwave radiation greater than config_bucket_radt"/>
 
                 <var name="lwcf" type="real" dimensions="nCells Time" units="W m^{-2}"
                      description="top-of-atmosphere cloud longwave radiative forcing"/>
@@ -3903,11 +3996,17 @@
                 <var name="lwdnbc" type="real" dimensions="nCells Time" units="W m^{-2}"
                      description="clear-sky downward surface longwave radiation flux"/>
 
+                <var name="lwdnbcln" type="real" dimensions="nCells Time" units="W m^{-2}"
+                     description="clean-sky downward surface longwave radiation flux"/>
+
                 <var name="lwdnt" type="real" dimensions="nCells Time" units="W m^{-2}"
                      description="all-sky downward top-of-the-atmosphere longwave radiation flux"/>
 
                 <var name="lwdntc" type="real" dimensions="nCells Time" units="W m^{-2}"
                      description="clear-sky downward top-of-the-atmosphere longwave radiation flux"/>
+
+                <var name="lwdntcln" type="real" dimensions="nCells Time" units="W m^{-2}"
+                     description="clean-sky downward top-of-the-atmosphere longwave radiation flux"/>
 
                 <var name="lwupb" type="real" dimensions="nCells Time" units="W m^{-2}"
                      description="all-sky upward surface longwave radiation flux"/>
@@ -3915,11 +4014,17 @@
                 <var name="lwupbc" type="real" dimensions="nCells Time" units="W m^{-2}"
                      description="clear-sky upward surface longwave radiation flux"/>
 
+                <var name="lwupbcln" type="real" dimensions="nCells Time" units="W m^{-2}"
+                     description="clean-sky upward surface longwave radiation flux"/>
+
                 <var name="lwupt" type="real" dimensions="nCells Time" units="W m^{-2}"
                      description="all-sky upward top-of-the-atmosphere longwave radiation flux"/>
 
                 <var name="lwuptc" type="real" dimensions="nCells Time" units="W m^{-2}"
                      description="clear-sky upward top-of-the-atmosphere longwave radiation flux"/>
+
+                <var name="lwuptcln" type="real" dimensions="nCells Time" units="W m^{-2}"
+                     description="clean-sky upward top-of-the-atmosphere longwave radiation flux"/>
 
                 <var name="aclwdnb" type="real" dimensions="nCells Time" units="W m^{-2}"
                      description="accumulated all-sky downward surface longwave radiation flux"/>
@@ -3927,11 +4032,17 @@
                 <var name="aclwdnbc" type="real" dimensions="nCells Time" units="W m^{-2}"
                      description="accumulated clear-sky downward surface longwave radiation flux"/>
 
+                <var name="aclwdnbcln" type="real" dimensions="nCells Time" units="W m^{-2}"
+                     description="accumulated clean-sky downward surface longwave radiation flux"/>
+
                 <var name="aclwdnt" type="real" dimensions="nCells Time" units="W m^{-2}"
                      description="accumulated all-sky downward top-of-the-atmosphere longwave radiation flux"/>
 
                 <var name="aclwdntc" type="real" dimensions="nCells Time" units="W m^{-2}"
                      description="accumulated clear-sky downward top-of-the-atmosphere longwave radiation flux"/>
+
+                <var name="aclwdntcln" type="real" dimensions="nCells Time" units="W m^{-2}"
+                     description="accumulated clean-sky downward top-of-the-atmosphere longwave radiation flux"/>
 
                 <var name="aclwupb" type="real" dimensions="nCells Time" units="W m^{-2}"
                      description="accumulated all-sky upward surface longwave radiation flux"/>
@@ -3939,11 +4050,17 @@
                 <var name="aclwupbc" type="real" dimensions="nCells Time" units="W m^{-2}"
                      description="accumulated clear-sky upward surface longwave radiation flux"/>
 
+                <var name="aclwupbcln" type="real" dimensions="nCells Time" units="W m^{-2}"
+                     description="accumulated clean-sky upward surface longwave radiation flux"/>
+
                 <var name="aclwupt" type="real" dimensions="nCells Time" units="W m^{-2}"
                      description="accumulated all-sky upward top-of-the-atmosphere longwave radiation flux"/>
 
                 <var name="aclwuptc" type="real" dimensions="nCells Time" units="W m^{-2}"
                      description="accumulated clear-sky upward top-of-the-atmosphere longwave radiation flux"/>
+
+                <var name="aclwuptcln" type="real" dimensions="nCells Time" units="W m^{-2}"
+                     description="accumulated clean-sky upward top-of-the-atmosphere longwave radiation flux"/>
 
                 <var name="olrtoa" type="real" dimensions="nCells Time" units="W m^{-2}"
                      description="all-sky top-of-atmosphere outgoing longwave radiation flux"/>
@@ -4387,7 +4504,10 @@
                      description="tendency of potential temperature due to short wave radiation"/>
 
                 <var name="rthratenlw" type="real" dimensions="nVertLevels nCells Time" units="K s^{-1}"
-                     description="tendency of potential temperature due to long wave radiation"/>
+			description="tendency of potential temperature due to long wave radiation"/>
+
+                <var name="rthratenlwc" type="real" dimensions="nVertLevels nCells Time" units="K s^{-1}"
+                     description="tendency of potential temperature due to clear-sky long wave radiation"/>
 #endif
         </var_struct>
 

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -3552,6 +3552,7 @@ module atm_time_integration
 ! Retrieval of K-eddy mixing array and things needed for second-order fluxes
       
       call mpas_pool_get_array(mesh, 'meshScalingDel2', meshScalingDel2)
+      call mpas_pool_get_array(mesh, 'meshScalingDel4', meshScalingDel4)
       call mpas_pool_get_array(diag, 'kdiff', kdiff)
       call mpas_pool_get_array(diag, 'rho_edge', rho_edge)
 

--- a/src/core_atmosphere/physics/mpas_atmphys_driver.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver.F
@@ -160,6 +160,8 @@
                                   config_radt_sw_scheme,    &
                                   config_sfclayer_scheme
 
+! logical, pointer:: config_calc_clean_atm_diag
+
  logical, pointer:: config_oml1d
  real(kind=RKIND),pointer:: config_bucket_radt
 
@@ -189,6 +191,7 @@
  call mpas_pool_get_config(domain%configs,'config_bucket_update'    ,config_bucket_update    )
  call mpas_pool_get_config(domain%configs,'config_frac_seaice'      ,config_frac_seaice      ) 
  call mpas_pool_get_config(domain%configs,'config_oml1d'            ,config_oml1d            )
+! call mpas_pool_get_config(domain%configs,'config_calc_clean_atm_diag', config_calc_clean_atm_diag)
 
  if(config_convection_scheme .ne. 'off' .or. &
     config_lsm_scheme        .ne. 'off' .or. &
@@ -251,6 +254,7 @@
        do thread=1,nThreads
           call driver_radiation_sw(itimestep,block%configs,mesh,state,time_lev,diag_physics, &
                                    atm_input,sfc_input,tend_physics,xtime_s, &
+!                                   atm_input,sfc_input,tend_physics,config_calc_clean_atm_diag,xtime_s, &
                                    cellSolveThreadStart(thread),cellSolveThreadEnd(thread))
        end do
 !$OMP END PARALLEL DO
@@ -264,6 +268,7 @@
        do thread=1,nThreads
           call driver_radiation_lw(xtime_s,block%configs,mesh,state,time_lev,diag_physics, &
                                    atm_input,sfc_input,tend_physics, &
+!                                   atm_input,sfc_input,tend_physics,config_calc_clean_atm_diag, &
                                    cellSolveThreadStart(thread),cellSolveThreadEnd(thread))
        end do
 !$OMP END PARALLEL DO

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_lw.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_lw.F
@@ -130,15 +130,20 @@
  if(.not.allocated(lwcf_p)       ) allocate(lwcf_p(ims:ime,jms:jme)               )
  if(.not.allocated(lwdnb_p)      ) allocate(lwdnb_p(ims:ime,jms:jme)              )
  if(.not.allocated(lwdnbc_p)     ) allocate(lwdnbc_p(ims:ime,jms:jme)             )
+ if(.not.allocated(lwdnbcln_p)   ) allocate(lwdnbcln_p(ims:ime,jms:jme)           )
  if(.not.allocated(lwdnt_p)      ) allocate(lwdnt_p(ims:ime,jms:jme)              )
  if(.not.allocated(lwdntc_p)     ) allocate(lwdntc_p(ims:ime,jms:jme)             )
+ if(.not.allocated(lwdntcln_p)   ) allocate(lwdntcln_p(ims:ime,jms:jme)           )
  if(.not.allocated(lwupb_p)      ) allocate(lwupb_p(ims:ime,jms:jme)              )
  if(.not.allocated(lwupbc_p)     ) allocate(lwupbc_p(ims:ime,jms:jme)             )
+ if(.not.allocated(lwupbcln_p)   ) allocate(lwupbcln_p(ims:ime,jms:jme)           )
  if(.not.allocated(lwupt_p)      ) allocate(lwupt_p(ims:ime,jms:jme)              )
  if(.not.allocated(lwuptc_p)     ) allocate(lwuptc_p(ims:ime,jms:jme)             )
+ if(.not.allocated(lwuptcln_p)   ) allocate(lwuptcln_p(ims:ime,jms:jme)           )
  if(.not.allocated(olrtoa_p)     ) allocate(olrtoa_p(ims:ime,jms:jme)             )
 
  if(.not.allocated(rthratenlw_p) ) allocate(rthratenlw_p(ims:ime,kms:kme,jms:jme) )
+ if(.not.allocated(rthratenlwc_p) ) allocate(rthratenlwc_p(ims:ime,kms:kme,jms:jme) )
 
  radiation_lw_select: select case (trim(radt_lw_scheme))
     case("rrtmg_lw")
@@ -155,8 +160,10 @@
 
        if(.not.allocated(lwdnflx_p)    ) allocate(lwdnflx_p(ims:ime,kms:kme+1,jms:jme)     )
        if(.not.allocated(lwdnflxc_p)   ) allocate(lwdnflxc_p(ims:ime,kms:kme+1,jms:jme)    )
+       if(.not.allocated(lwdnflxcln_p) ) allocate(lwdnflxcln_p(ims:ime,kms:kme+1,jms:jme)  )
        if(.not.allocated(lwupflx_p)    ) allocate(lwupflx_p(ims:ime,kms:kme+1,jms:jme)     )
        if(.not.allocated(lwupflxc_p)   ) allocate(lwupflxc_p(ims:ime,kms:kme+1,jms:jme)    )
+       if(.not.allocated(lwupflxcln_p) ) allocate(lwupflxcln_p(ims:ime,kms:kme+1,jms:jme)  )
 
        if(.not.allocated(pin_p)        ) allocate(pin_p(num_oznlevels)                     )
        if(.not.allocated(o3clim_p)     ) allocate(o3clim_p(ims:ime,1:num_oznlevels,jms:jme))
@@ -233,15 +240,20 @@
  if(allocated(lwcf_p)       ) deallocate(lwcf_p       )
  if(allocated(lwdnb_p)      ) deallocate(lwdnb_p      )
  if(allocated(lwdnbc_p)     ) deallocate(lwdnbc_p     )
+ if(allocated(lwdnbcln_p)   ) deallocate(lwdnbcln_p   )
  if(allocated(lwdnt_p)      ) deallocate(lwdnt_p      )
  if(allocated(lwdntc_p)     ) deallocate(lwdntc_p     )
+ if(allocated(lwdntcln_p)   ) deallocate(lwdntcln_p   )
  if(allocated(lwupb_p)      ) deallocate(lwupb_p      )
  if(allocated(lwupbc_p)     ) deallocate(lwupbc_p     )
+ if(allocated(lwupbcln_p)   ) deallocate(lwupbcln_p   )
  if(allocated(lwupt_p)      ) deallocate(lwupt_p      )
  if(allocated(lwuptc_p)     ) deallocate(lwuptc_p     )
+ if(allocated(lwuptcln_p)   ) deallocate(lwuptcln_p   )
  if(allocated(olrtoa_p)     ) deallocate(olrtoa_p     )
  
  if(allocated(rthratenlw_p) ) deallocate(rthratenlw_p )
+ if(allocated(rthratenlwc_p) ) deallocate(rthratenlwc_p )
 
  radiation_lw_select: select case (trim(radt_lw_scheme))
     case("rrtmg_lw")
@@ -254,8 +266,10 @@
 
        if(allocated(lwdnflx_p)    ) deallocate(lwdnflx_p    )
        if(allocated(lwdnflxc_p)   ) deallocate(lwdnflxc_p   )
+       if(allocated(lwdnflxcln_p) ) deallocate(lwdnflxcln_p )
        if(allocated(lwupflx_p)    ) deallocate(lwupflx_p    )
        if(allocated(lwupflxc_p)   ) deallocate(lwupflxc_p   )
+       if(allocated(lwupflxcln_p) ) deallocate(lwupflxcln_p )
 
        if(allocated(pin_p)        ) deallocate(pin_p        )
        if(allocated(o3clim_p)     ) deallocate(o3clim_p     )
@@ -299,6 +313,7 @@
 !=================================================================================================================
  subroutine radiation_lw_from_MPAS(xtime_s,configs,mesh,state,time_lev,diag_physics,atm_input, &
                                    sfc_input,its,ite)
+!                                   config_calc_clean_atm_diag, sfc_input,its,ite) debug testing, Minsu Choi
 !=================================================================================================================
 
 !input arguments:
@@ -319,6 +334,7 @@
 
 !local pointers:
  logical,pointer:: config_o3climatology
+ logical,pointer:: config_calc_clean_atm_diag
  logical,pointer:: config_microp_re
  character(len=StrKIND),pointer:: radt_lw_scheme
  character(len=StrKIND),pointer:: microp_scheme
@@ -342,6 +358,7 @@
  call mpas_pool_get_config(configs,'config_o3climatology' ,config_o3climatology)
  call mpas_pool_get_config(configs,'config_radt_lw_scheme',radt_lw_scheme      )
  call mpas_pool_get_config(configs,'config_microp_scheme' ,microp_scheme       )
+ call mpas_pool_get_config(configs,'config_calc_clean_atm_diag', config_calc_clean_atm_diag)
 
  call mpas_pool_get_array(mesh,'latCell',latCell)
  call mpas_pool_get_array(mesh,'lonCell',lonCell)
@@ -397,18 +414,23 @@
     lwcf_p(i,j)     = 0.0_RKIND
     lwdnb_p(i,j)    = 0.0_RKIND
     lwdnbc_p(i,j)   = 0.0_RKIND
+    lwdnbcln_p(i,j) = 0.0_RKIND
     lwdnt_p(i,j)    = 0.0_RKIND
     lwdntc_p(i,j)   = 0.0_RKIND
+    lwdntcln_p(i,j) = 0.0_RKIND
     lwupb_p(i,j)    = 0.0_RKIND
     lwupbc_p(i,j)   = 0.0_RKIND
+    lwupbcln_p(i,j) = 0.0_RKIND
     lwupt_p(i,j)    = 0.0_RKIND
     lwuptc_p(i,j)   = 0.0_RKIND
+    lwuptcln_p(i,j) = 0.0_RKIND
     olrtoa_p(i,j)   = 0.0_RKIND
  enddo
  
  do k = kts,kte
  do i = its,ite
     rthratenlw_p(i,k,j) = 0.0_RKIND
+    rthratenlwc_p(i,k,j) = 0.0_RKIND
  enddo
  enddo
  enddo
@@ -504,8 +526,10 @@
        do i = its,ite
           lwdnflx_p(i,k,j)  = 0.0_RKIND
           lwdnflxc_p(i,k,j) = 0.0_RKIND
+          lwdnflxcln_p(i,k,j) = 0.0_RKIND
           lwupflx_p(i,k,j)  = 0.0_RKIND
           lwupflxc_p(i,k,j) = 0.0_RKIND
+          lwupflxcln_p(i,k,j) = 0.0_RKIND
        enddo
        enddo
        enddo
@@ -568,12 +592,16 @@
           swcf_p(i,j)       = 0.0_RKIND
           swdnb_p(i,j)      = 0.0_RKIND
           swdnbc_p(i,j)     = 0.0_RKIND
+          swdnbcln_p(i,j)   = 0.0_RKIND
           swdnt_p(i,j)      = 0.0_RKIND
           swdntc_p(i,j)     = 0.0_RKIND
+          swdntcln_p(i,j)   = 0.0_RKIND
           swupb_p(i,j)      = 0.0_RKIND
           swupbc_p(i,j)     = 0.0_RKIND
+          swupbcln_p(i,j)   = 0.0_RKIND
           swupt_p(i,j)      = 0.0_RKIND
           swuptc_p(i,j)     = 0.0_RKIND
+          swuptcln_p(i,j)   = 0.0_RKIND
        enddo
        do k = kts,kte
        do i = its,ite
@@ -672,7 +700,8 @@
 
  real(kind=RKIND),dimension(:),pointer :: glw,lwcf,lwdnb,lwdnbc,lwdnt,lwdntc,lwupb,lwupbc, &
                                           lwupt,lwuptc,olrtoa
- real(kind=RKIND),dimension(:,:),pointer:: rthratenlw
+ real(kind=RKIND),dimension(:),pointer :: lwdnbcln,lwdntcln,lwupbcln,lwuptcln
+ real(kind=RKIND),dimension(:,:),pointer:: rthratenlw, rthratenlwc
  real(kind=RKIND),dimension(:,:),pointer:: rre_cloud,rre_ice,rre_snow
 
 !local variables and arrays:
@@ -690,15 +719,20 @@
  call mpas_pool_get_array(diag_physics,'lwcf'  ,lwcf  )
  call mpas_pool_get_array(diag_physics,'lwdnb' ,lwdnb )
  call mpas_pool_get_array(diag_physics,'lwdnbc',lwdnbc)
+ call mpas_pool_get_array(diag_physics,'lwdnbcln',lwdnbcln)
  call mpas_pool_get_array(diag_physics,'lwdnt' ,lwdnt )
  call mpas_pool_get_array(diag_physics,'lwdntc',lwdntc)
+ call mpas_pool_get_array(diag_physics,'lwdntcln',lwdntcln)
  call mpas_pool_get_array(diag_physics,'lwupb' ,lwupb )
  call mpas_pool_get_array(diag_physics,'lwupbc',lwupbc)
+ call mpas_pool_get_array(diag_physics,'lwupbcln',lwupbcln)
  call mpas_pool_get_array(diag_physics,'lwupt' ,lwupt )
  call mpas_pool_get_array(diag_physics,'lwuptc',lwuptc)
+ call mpas_pool_get_array(diag_physics,'lwuptcln',lwuptcln)
  call mpas_pool_get_array(diag_physics,'olrtoa',olrtoa)
 
  call mpas_pool_get_array(tend_physics,'rthratenlw',rthratenlw)
+ call mpas_pool_get_array(tend_physics,'rthratenlwc',rthratenlwc)
 
  do j = jts,jte
  do i = its,ite
@@ -706,18 +740,23 @@
     lwcf(i)   = lwcf_p(i,j)
     lwdnb(i)  = lwdnb_p(i,j)
     lwdnbc(i) = lwdnbc_p(i,j)
+    lwdnbcln(i) = lwdnbcln_p(i,j)
     lwdnt(i)  = lwdnt_p(i,j)
     lwdntc(i) = lwdntc_p(i,j)
+    lwdntcln(i) = lwdntcln_p(i,j)
     lwupb(i)  = lwupb_p(i,j)
     lwupbc(i) = lwupbc_p(i,j)
+    lwupbcln(i) = lwupbcln_p(i,j)
     lwupt(i)  = lwupt_p(i,j)
     lwuptc(i) = lwuptc_p(i,j)
+    lwuptcln(i) = lwuptcln_p(i,j)
     olrtoa(i) = olrtoa_p(i,j)
  enddo
 
  do k = kts,kte
  do i = its,ite
     rthratenlw(k,i) = rthratenlw_p(i,k,j)
+    rthratenlwc(k,i) = rthratenlwc_p(i,k,j)
  enddo
  enddo
  enddo
@@ -872,6 +911,7 @@
 !=================================================================================================================
  subroutine driver_radiation_lw(xtime_s,configs,mesh,state,time_lev,diag_physics,atm_input, &
                                 sfc_input,tend_physics,its,ite)
+!                                sfc_input,tend_physics,config_calc_clean_atm_diag,its,ite)
 !=================================================================================================================
 
 !input arguments:
@@ -891,6 +931,7 @@
 
 !local pointers:
  logical,pointer:: config_o3climatology
+ logical,pointer:: config_calc_clean_atm_diag
  character(len=StrKIND),pointer:: radt_lw_scheme
  character(len=StrKIND),pointer:: radt_cld_overlap,radt_cld_dcorrlen
 
@@ -906,9 +947,12 @@
  call mpas_pool_get_config(configs,'config_radt_lw_scheme'   ,radt_lw_scheme      )
  call mpas_pool_get_config(configs,'config_radt_cld_overlap' ,radt_cld_overlap    )
  call mpas_pool_get_config(configs,'config_radt_cld_dcorrlen',radt_cld_dcorrlen   )
+ call mpas_pool_get_config(configs,'config_calc_clean_atm_diag', config_calc_clean_atm_diag)
 
 !copy MPAS arrays to local arrays:
  call radiation_lw_from_MPAS(xtime_s,configs,mesh,state,time_lev,diag_physics,atm_input,sfc_input,its,ite)
+ !Debug testing, Minsu Choi
+ !call radiation_lw_from_MPAS(xtime_s,configs,mesh,state,time_lev,diag_physics,atm_input,config_calc_clean_atm_diag,sfc_input,its,ite)
 
 !call to longwave radiation scheme:
  radiation_lw_select: select case (trim(radt_lw_scheme))
@@ -941,13 +985,17 @@
             icloud   = icloud      , cldovrlp   = cldovrlp      , idcor     = idcor      , &
             o3input  = o3input     , noznlevels = num_oznlevels , pin       = pin_p      , &
             o3clim   = o3clim_p    , glw        = glw_p         , olr       = olrtoa_p   , &
-            lwcf     = lwcf_p      , rthratenlw = rthratenlw_p  , has_reqc  = has_reqc   , &
+            lwcf     = lwcf_p      , rthratenlw = rthratenlw_p  , rthratenlwc = rthratenlwc_p, &
+            has_reqc  = has_reqc   , &
             has_reqi = has_reqi    , has_reqs   = has_reqs      , re_cloud  = recloud_p  , &
             re_ice   = reice_p     , re_snow    = resnow_p      , rre_cloud = rrecloud_p , &
             rre_ice  = rreice_p    , rre_snow   = rresnow_p     , lwupt     = lwupt_p    , &
-            lwuptc   = lwuptc_p    , lwdnt      = lwdnt_p       , lwdntc    = lwdntc_p   , &
-            lwupb    = lwupb_p     , lwupbc     = lwupbc_p      , lwdnb     = lwdnb_p    , &
-            lwdnbc   = lwdnbc_p    ,                                                       &
+            lwuptc   = lwuptc_p    , lwuptcln   = lwuptcln_p    , lwdnt     = lwdnt_p    , &
+            lwdntc   = lwdntc_p    , lwdntcln   = lwdntcln_p    , lwupb     = lwupb_p    , &
+            lwupbc   = lwupbc_p    , lwupbcln   = lwupbcln_p , &
+            lwdnb    = lwdnb_p     , lwdnbc     = lwdnbc_p      , lwdnbcln  = lwdnbcln_p , &
+            lwupflx   = lwupflx_p  , lwupflxc   = lwupflxc_p    , lwdnflx   = lwdnflx_p  , &
+            lwdnflxc  = lwdnflxc_p , config_calc_clean_atm_diag = config_calc_clean_atm_diag, &
             ids = ids , ide = ide , jds = jds , jde = jde , kds = kds , kde = kde ,        &
             ims = ims , ime = ime , jms = jms , jme = jme , kms = kms , kme = kme ,        &
             its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte          &

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_sw.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_sw.F
@@ -137,14 +137,19 @@
  if(.not.allocated(swcf_p)       ) allocate(swcf_p(ims:ime,jms:jme)               )
  if(.not.allocated(swdnb_p)      ) allocate(swdnb_p(ims:ime,jms:jme)              )
  if(.not.allocated(swdnbc_p)     ) allocate(swdnbc_p(ims:ime,jms:jme)             )
+ if(.not.allocated(swdnbcln_p)   ) allocate(swdnbcln_p(ims:ime,jms:jme)           ) !Clean sky testing
  if(.not.allocated(swdnt_p)      ) allocate(swdnt_p(ims:ime,jms:jme)              )
  if(.not.allocated(swdntc_p)     ) allocate(swdntc_p(ims:ime,jms:jme)             )
+ if(.not.allocated(swdntcln_p)   ) allocate(swdntcln_p(ims:ime,jms:jme)           ) !Clean sky testing
  if(.not.allocated(swupb_p)      ) allocate(swupb_p(ims:ime,jms:jme)              )
  if(.not.allocated(swupbc_p)     ) allocate(swupbc_p(ims:ime,jms:jme)             )
+ if(.not.allocated(swupbcln_p)   ) allocate(swupbcln_p(ims:ime,jms:jme)           ) !Clean sky testing
  if(.not.allocated(swupt_p)      ) allocate(swupt_p(ims:ime,jms:jme)              )
  if(.not.allocated(swuptc_p)     ) allocate(swuptc_p(ims:ime,jms:jme)             )
+ if(.not.allocated(swuptcln_p)   ) allocate(swuptcln_p(ims:ime,jms:jme)           ) !Clean sky testing
  
  if(.not.allocated(rthratensw_p) ) allocate(rthratensw_p(ims:ime,kms:kme,jms:jme) )
+! if(.not.allocated(rthratenswc_p) ) allocate(rthratenswc_p(ims:ime,kms:kme,jms:jme) )
 
  radiation_sw_select: select case (trim(radt_sw_scheme))
     case("rrtmg_sw")
@@ -167,8 +172,10 @@
 
        if(.not.allocated(swdnflx_p)    ) allocate(swdnflx_p(ims:ime,kms:kme+1,jms:jme)     )
        if(.not.allocated(swdnflxc_p)   ) allocate(swdnflxc_p(ims:ime,kms:kme+1,jms:jme)    )
+       if(.not.allocated(swdnflxcln_p) ) allocate(swdnflxcln_p(ims:ime,kms:kme+1,jms:jme)  ) !Clean sky testing
        if(.not.allocated(swupflx_p)    ) allocate(swupflx_p(ims:ime,kms:kme+1,jms:jme)     )
        if(.not.allocated(swupflxc_p)   ) allocate(swupflxc_p(ims:ime,kms:kme+1,jms:jme)    )
+       if(.not.allocated(swupflxcln_p) ) allocate(swupflxcln_p(ims:ime,kms:kme+1,jms:jme)  ) !Clean sky testing
 
        if(.not.allocated(pin_p)        ) allocate(pin_p(num_oznlevels)                     )
        if(.not.allocated(o3clim_p)     ) allocate(o3clim_p(ims:ime,1:num_oznlevels,jms:jme))
@@ -273,14 +280,19 @@
  if(allocated(swcf_p)       ) deallocate(swcf_p       )
  if(allocated(swdnb_p)      ) deallocate(swdnb_p      )
  if(allocated(swdnbc_p)     ) deallocate(swdnbc_p     )
+ if(allocated(swdnbcln_p)   ) deallocate(swdnbcln_p   )!Clean sky
  if(allocated(swdnt_p)      ) deallocate(swdnt_p      )
  if(allocated(swdntc_p)     ) deallocate(swdntc_p     )
+ if(allocated(swdntcln_p)   ) deallocate(swdntcln_p   )!Clean sky
  if(allocated(swupb_p)      ) deallocate(swupb_p      )
  if(allocated(swupbc_p)     ) deallocate(swupbc_p     )
+ if(allocated(swupbcln_p)   ) deallocate(swupbcln_p   )!Clean sky
  if(allocated(swupt_p)      ) deallocate(swupt_p      )
  if(allocated(swuptc_p)     ) deallocate(swuptc_p     )
+ if(allocated(swuptcln_p)   ) deallocate(swuptcln_p   )!Clean sky
  
  if(allocated(rthratensw_p) ) deallocate(rthratensw_p )
+! if(allocated(rthratenswc_p) ) deallocate(rthratenswc_p )
 
  radiation_sw_select: select case (trim(radt_sw_scheme))
     case("rrtmg_sw")
@@ -303,8 +315,10 @@
 
        if(allocated(swdnflx_p)    ) deallocate(swdnflx_p    )
        if(allocated(swdnflxc_p)   ) deallocate(swdnflxc_p   )
+       if(allocated(swdnflxcln_p) ) deallocate(swdnflxcln_p )
        if(allocated(swupflx_p)    ) deallocate(swupflx_p    )
        if(allocated(swupflxc_p)   ) deallocate(swupflxc_p   )
+       if(allocated(swupflxcln_p) ) deallocate(swupflxcln_p )
 
        if(allocated(pin_p)        ) deallocate(pin_p        )
        if(allocated(o3clim_p)     ) deallocate(o3clim_p     )
@@ -369,6 +383,7 @@
 !=================================================================================================================
  subroutine radiation_sw_from_MPAS(configs,mesh,state,time_lev,diag_physics,atm_input, &
                                    sfc_input,xtime_s,its,ite)
+!                                   config_calc_clean_atm_diag, sfc_input,xtime_s,its,ite)
 !=================================================================================================================
 
 !input arguments:
@@ -381,6 +396,7 @@
 
  integer,intent(in):: its,ite
  integer,intent(in):: time_lev
+! integer,intent(in):: config_calc_clean_atm_diag
 
  real(kind=RKIND),intent(in):: xtime_s
 
@@ -391,6 +407,7 @@
  logical,pointer:: config_o3climatology
  logical,pointer:: config_microp_re
  logical,pointer:: config_tempo_aerosolaware
+ logical,pointer:: config_calc_clean_atm_diag
  character(len=StrKIND),pointer:: radt_sw_scheme
  character(len=StrKIND),pointer:: microp_scheme
 
@@ -470,12 +487,16 @@
     swcf_p(i,j)     = 0.0_RKIND
     swdnb_p(i,j)    = 0.0_RKIND
     swdnbc_p(i,j)   = 0.0_RKIND
+    swdnbcln_p(i,j) = 0.0_RKIND
     swdnt_p(i,j)    = 0.0_RKIND
     swdntc_p(i,j)   = 0.0_RKIND
+    swdntcln_p(i,j) = 0.0_RKIND
     swupb_p(i,j)    = 0.0_RKIND
     swupbc_p(i,j)   = 0.0_RKIND
+    swupbcln_p(i,j) = 0.0_RKIND
     swupt_p(i,j)    = 0.0_RKIND
     swuptc_p(i,j)   = 0.0_RKIND
+    swuptcln_p(i,j) = 0.0_RKIND
     swddir_p(i,j)   = 0.0_RKIND
     swddni_p(i,j)   = 0.0_RKIND
     swddif_p(i,j)   = 0.0_RKIND
@@ -484,6 +505,7 @@
  do k = kts,kte
  do i = its,ite
     rthratensw_p(i,k,j) = 0.0_RKIND
+!    rthratenswc_p(i,k,j) = 0.0_RKIND
  enddo
  enddo
  enddo
@@ -687,8 +709,10 @@
        do i = its,ite
           swdnflx_p(i,k,j)  = 0.0_RKIND
           swdnflxc_p(i,k,j) = 0.0_RKIND
+          swdnflxcln_p(i,k,j) = 0.0_RKIND  ! Clean diagnostics
           swupflx_p(i,k,j)  = 0.0_RKIND
           swupflxc_p(i,k,j) = 0.0_RKIND
+          swupflxcln_p(i,k,j) = 0.0_RKIND ! Clean diagnostics
        enddo
        enddo
        enddo
@@ -824,7 +848,8 @@
  real(kind=RKIND),dimension(:),pointer  :: coszr,gsw,swcf,swdnb,swdnbc,swdnt,swdntc, &
                                            swupb,swupbc,swupt,swuptc,swddir,swddni,  &
                                            swddif
- real(kind=RKIND),dimension(:,:),pointer:: rthratensw
+ real(kind=RKIND),dimension(:),pointer  :: swdnbcln, swdntcln, swuptcln, swupbcln                                   
+ real(kind=RKIND),dimension(:,:),pointer:: rthratensw !,rthratenswc
 
 !-----------------------------------------------------------------------------------------------------------------
 !call mpas_log_write(' ')
@@ -835,39 +860,49 @@
  call mpas_pool_get_array(diag_physics,'swcf'      ,swcf      )
  call mpas_pool_get_array(diag_physics,'swdnb'     ,swdnb     )
  call mpas_pool_get_array(diag_physics,'swdnbc'    ,swdnbc    )
+ call mpas_pool_get_array(diag_physics,'swdnbcln'  ,swdnbcln  ) ! Clean Diagnostic
  call mpas_pool_get_array(diag_physics,'swdnt'     ,swdnt     )
  call mpas_pool_get_array(diag_physics,'swdntc'    ,swdntc    )
+ call mpas_pool_get_array(diag_physics,'swdntcln'  ,swdntcln  ) ! Clean Diagnostic
  call mpas_pool_get_array(diag_physics,'swupb'     ,swupb     )
  call mpas_pool_get_array(diag_physics,'swupbc'    ,swupbc    )
+ call mpas_pool_get_array(diag_physics,'swupbcln'  ,swupbcln  ) ! Clean Diagnostic
  call mpas_pool_get_array(diag_physics,'swupt'     ,swupt     )
  call mpas_pool_get_array(diag_physics,'swuptc'    ,swuptc    )
+ call mpas_pool_get_array(diag_physics,'swuptcln'  ,swuptcln  ) ! Clean Diagnostic
  call mpas_pool_get_array(diag_physics,'swddir'    ,swddir    )
  call mpas_pool_get_array(diag_physics,'swddni'    ,swddni    )
  call mpas_pool_get_array(diag_physics,'swddif'    ,swddif    )
  call mpas_pool_get_array(tend_physics,'rthratensw',rthratensw)
+! call mpas_pool_get_array(tend_physics,'rthratenswc',rthratenswc)
 
  do j = jts,jte
-
  do i = its,ite
     coszr(i) = coszr_p(i,j)
     gsw(i)    = gsw_p(i,j)
     swcf(i)   = swcf_p(i,j)
     swdnb(i)  = swdnb_p(i,j)
     swdnbc(i) = swdnbc_p(i,j)
+    swdnbcln(i) = swdnbcln_p(i,j)
     swdnt(i)  = swdnt_p(i,j)
     swdntc(i) = swdntc_p(i,j)
+    swdntcln(i) = swdntcln_p(i,j)
     swupb(i)  = swupb_p(i,j)
     swupbc(i) = swupbc_p(i,j)
+    swupbcln(i) = swupbcln_p(i,j)
     swupt(i)  = swupt_p(i,j)
     swuptc(i) = swuptc_p(i,j)
+    swuptcln(i) = swuptcln_p(i,j)
     swddir(i) = swddir_p(i,j)
     swddni(i) = swddni_p(i,j)
     swddif(i) = swddif_p(i,j)
  enddo
+! enddo
 
  do k = kts,kte
  do i = its,ite
     rthratensw(k,i) = rthratensw_p(i,k,j)
+!    rthratenswc(k,i) = rthratenswc_p(i,k,j)
  enddo
  enddo
 
@@ -918,6 +953,7 @@
 !=================================================================================================================
  subroutine driver_radiation_sw(itimestep,configs,mesh,state,time_lev,diag_physics,atm_input, &
                                 sfc_input,tend_physics,xtime_s,its,ite)
+!                                sfc_input,tend_physics,config_calc_clean_atm_diag,xtime_s,its,ite)
 !=================================================================================================================
 
 !input arguments:
@@ -940,6 +976,7 @@
 
 !local pointers:
  logical,pointer:: config_o3climatology
+ logical,pointer:: config_calc_clean_atm_diag
  character(len=StrKIND),pointer:: radt_sw_scheme
  character(len=StrKIND),pointer:: radt_cld_overlap,radt_cld_dcorrlen
 
@@ -955,11 +992,21 @@
  call mpas_pool_get_config(configs,'config_radt_sw_scheme',radt_sw_scheme         )
  call mpas_pool_get_config(configs,'config_radt_cld_overlap' ,radt_cld_overlap    )
  call mpas_pool_get_config(configs,'config_radt_cld_dcorrlen',radt_cld_dcorrlen   )
+ call mpas_pool_get_config(configs,'config_calc_clean_atm_diag', config_calc_clean_atm_diag)
+
+ call mpas_log_write('=== DEBUG: config_calc_clean_atm_diag check ===')
+ if (config_calc_clean_atm_diag) then
+   call mpas_log_write('config_calc_clean_atm_diag = TRUE')
+ else
+   call mpas_log_write('config_calc_clean_atm_diag = FALSE')
+ endif
+ call mpas_log_write('===============================================')
 
  xtime_m = xtime_s/60.
 
 !copy MPAS arrays to local arrays:
  call radiation_sw_from_MPAS(configs,mesh,state,time_lev,diag_physics,atm_input,sfc_input,xtime_s,its,ite)
+ !call radiation_sw_from_MPAS(configs,mesh,state,time_lev,diag_physics,atm_input,config_calc_clean_atm_diag,sfc_input,xtime_s,its,ite)
 
 ! This should be OMP MASTER with barrier afterwards or OMP SINGLE, since declin and solcon
 ! are global variables in mpas_atmphys_vars.F and race conditions may occur otherwise!
@@ -1000,6 +1047,14 @@
           if(trim(radt_cld_dcorrlen) == "latitude_varying") idcor = 1
        endif
 
+       call mpas_log_write('=== DEBUG: Before calling rrtmg_swrad ===')
+       if (config_calc_clean_atm_diag) then
+          call mpas_log_write('Passing config_calc_clean_atm_diag = TRUE (logical)')
+       else
+          call mpas_log_write('Passing config_calc_clean_atm_diag = FALSE (logical)')
+       endif
+       call mpas_log_write('===========================================')
+
        call mpas_timer_start('rrtmg_swrad')
        call rrtmg_swrad( &
               p3d        = pres_hyd_p    , p8w      = pres2_hyd_p , pi3d     = pi_p           , &
@@ -1016,18 +1071,28 @@
               cldovrlp   = cldovrlp      , idcor    = idcor       , o3input  = o3input        , &
               noznlevels = num_oznlevels , pin      = pin_p       , o3clim   = o3clim_p       , &
               gsw        = gsw_p         , swcf     = swcf_p      , rthratensw = rthratensw_p , &
+!              rthratenswc = rthratenswc_p, &
               has_reqc   = has_reqc      , has_reqi = has_reqi    , has_reqs   = has_reqs     , &
               re_cloud   = recloud_p     , re_ice   = reice_p     , re_snow    = resnow_p     , &
               aer_opt    = aer_opt       , tauaer3d = tauaer_p    , ssaaer3d   = ssaaer_p     , &
               asyaer3d   = asyaer_p      , swupt    = swupt_p     , swuptc     = swuptc_p     , &
-              swdnt      = swdnt_p       , swdntc   = swdntc_p    , swupb      = swupb_p      , &
-              swupbc     = swupbc_p      , swdnb    = swdnb_p     , swdnbc     = swdnbc_p     , &
-              swddir     = swddir_p      , swddni   = swddni_p    , swddif     = swddif_p     , &
+              swuptcln   = swuptcln_p    , swdnt    = swdnt_p  , &
+              swdntc     = swdntc_p     , swdntcln   = swdntcln_p    , swupb    = swupb_p  , &
+              swupbc     = swupbc_p     , swupbcln   = swupbcln_p    , swdnb    = swdnb_p  , &
+              swdnbc     = swdnbc_p     , swdnbcln   = swdnbcln_p    , swupflx  = swupflx_p, &
+              swupflxc   = swupflxc_p   , swupflxcln = swupflxcln_p  , swdnflx  = swdnflx_p, &
+              swdnflxc   = swdnflxc_p   , swdnflxcln = swdnflxcln_p  , swddir   = swddir_p , &
+              swddni     = swddni_p     , swddif     = swddif_p      , &
+              config_calc_clean_atm_diag=config_calc_clean_atm_diag, &
               ids = ids , ide = ide , jds = jds , jde = jde , kds = kds , kde = kde ,           &
               ims = ims , ime = ime , jms = jms , jme = jme , kms = kms , kme = kme ,           &
               its = its , ite = ite , jts = jts , jte = jte , kts = kts , kte = kte             &
                        )
        call mpas_timer_stop('rrtmg_swrad')
+       call mpas_log_write('=== DEBUG: Clean diagnostic values after rrtmg_swrad ===')
+       call mpas_log_write('swdnbcln_p min/max: $r $r', realArgs=(/minval(swdnbcln_p), maxval(swdnbcln_p)/))
+       call mpas_log_write('swuptcln_p min/max: $r $r', realArgs=(/minval(swuptcln_p), maxval(swuptcln_p)/))
+       call mpas_log_write('========================================================')
 
     case ("cam_sw")
        call mpas_timer_start('camrad_sw')

--- a/src/core_atmosphere/physics/mpas_atmphys_init.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_init.F
@@ -111,7 +111,8 @@ use mpas_stream_manager
  logical,pointer:: config_do_restart,    &
                    config_do_DAcycling,  &
                    config_o3climatology, &
-                   config_oml1d
+                   config_oml1d,&
+                   config_calc_clean_atm_diag
 
  character(len=StrKIND),pointer::            &
                    config_convection_scheme, &
@@ -130,11 +131,15 @@ use mpas_stream_manager
                                 i_acswupb,i_acswupbc,i_acswupt,i_acswuptc, &
                                 i_aclwdnb,i_aclwdnbc,i_aclwdnt,i_aclwdntc, &
                                 i_aclwupb,i_aclwupbc,i_aclwupt,i_aclwuptc
+ integer,dimension(:),pointer:: i_acswdnbcln,i_acswdntcln,i_acswuptcln,i_aclwdnbcln, &
+                                i_aclwdntcln,i_aclwupbcln,i_aclwuptcln,i_acswupbcln
 
  real(kind=RKIND),dimension(:),pointer:: acswdnb,acswdnbc,acswdnt,acswdntc, &
                                          acswupb,acswupbc,acswupt,acswuptc, &
                                          aclwdnb,aclwdnbc,aclwdnt,aclwdntc, &
                                          aclwupb,aclwupbc,aclwupt,aclwuptc
+ real(kind=RKIND),dimension(:),pointer:: acswdnbcln,acswdntcln,acswupbcln,&
+                                         acswuptcln,aclwdnbcln,aclwupbcln,aclwuptcln,aclwdntcln
  real(kind=RKIND),dimension(:),pointer:: nsteps_accum,ndays_accum,tday_accum, &
                                          tyear_accum,tyear_mean
  real(kind=RKIND),dimension(:),pointer:: sst,sstsk,tmn,xice,xicem
@@ -178,43 +183,66 @@ use mpas_stream_manager
  call mpas_pool_get_config(configs,'config_radt_sw_scheme'   ,config_radt_sw_scheme   )
  call mpas_pool_get_config(configs,'config_smoke_scheme'     ,config_smoke_scheme     )
  call mpas_pool_get_config(configs,'config_dust_scheme'      ,config_dust_scheme      )
+! clean diagnostics added by Minsu Choi, CIRES/NOAA GSL 
+ call mpas_pool_get_config(configs,'config_calc_clean_atm_diag', config_calc_clean_atm_diag)
+! if (diag_physics % config_calc_clean_atm_diag .AND. config_aer_ra_feedback <= 0) then
+!   call mpas_log_write('FATAL: Clean sky diagnostics (config_calc_clean_atm_diag) require '// &
+!         'aerosol-radiation feedback to be enabled (config_aer_ra_feedback > 0).')
+!   call mpas_abort()
+! endif
 
  call mpas_pool_get_dimension(mesh,'nCellsSolve',nCellsSolve)
  call mpas_pool_get_dimension(mesh,'nLags'      ,nLags      )
 
  call mpas_pool_get_array(diag_physics,'i_acswdnb'   ,i_acswdnb   )
  call mpas_pool_get_array(diag_physics,'i_acswdnbc'  ,i_acswdnbc  )
+ call mpas_pool_get_array(diag_physics,'i_acswdnbcln',i_acswdnbcln)
  call mpas_pool_get_array(diag_physics,'i_acswdnt'   ,i_acswdnt   )
  call mpas_pool_get_array(diag_physics,'i_acswdntc'  ,i_acswdntc  )
+ call mpas_pool_get_array(diag_physics,'i_acswdntcln',i_acswdntcln)
  call mpas_pool_get_array(diag_physics,'i_acswupb'   ,i_acswupb   )
  call mpas_pool_get_array(diag_physics,'i_acswupbc'  ,i_acswupbc  )
+ call mpas_pool_get_array(diag_physics,'i_acswupbcln',i_acswupbcln)
  call mpas_pool_get_array(diag_physics,'i_acswupt'   ,i_acswupt   )
  call mpas_pool_get_array(diag_physics,'i_acswuptc'  ,i_acswuptc  )
+ call mpas_pool_get_array(diag_physics,'i_acswuptcln',i_acswuptcln)
  call mpas_pool_get_array(diag_physics,'i_aclwdnb'   ,i_aclwdnb   )
  call mpas_pool_get_array(diag_physics,'i_aclwdnbc'  ,i_aclwdnbc  )
+ call mpas_pool_get_array(diag_physics,'i_aclwdnbcln',i_aclwdnbcln)
  call mpas_pool_get_array(diag_physics,'i_aclwdnt'   ,i_aclwdnt   )
  call mpas_pool_get_array(diag_physics,'i_aclwdntc'  ,i_aclwdntc  )
+ call mpas_pool_get_array(diag_physics,'i_aclwdntcln',i_aclwdntcln)
  call mpas_pool_get_array(diag_physics,'i_aclwupb'   ,i_aclwupb   )
  call mpas_pool_get_array(diag_physics,'i_aclwupbc'  ,i_aclwupbc  )
+ call mpas_pool_get_array(diag_physics,'i_aclwupbcln',i_aclwupbcln)
  call mpas_pool_get_array(diag_physics,'i_aclwupt'   ,i_aclwupt   )
  call mpas_pool_get_array(diag_physics,'i_aclwuptc'  ,i_aclwuptc  )
+ call mpas_pool_get_array(diag_physics,'i_aclwuptcln',i_aclwuptcln)
 
  call mpas_pool_get_array(diag_physics,'acswdnb'     ,acswdnb     )
  call mpas_pool_get_array(diag_physics,'acswdnbc'    ,acswdnbc    )
+ call mpas_pool_get_array(diag_physics,'acswdnbcln'  ,acswdnbcln  )
  call mpas_pool_get_array(diag_physics,'acswdnt'     ,acswdnt     )
  call mpas_pool_get_array(diag_physics,'acswdntc'    ,acswdntc    )
+ call mpas_pool_get_array(diag_physics,'acswdntcln'  ,acswdntcln  )
  call mpas_pool_get_array(diag_physics,'acswupb'     ,acswupb     )
  call mpas_pool_get_array(diag_physics,'acswupbc'    ,acswupbc    )
+ call mpas_pool_get_array(diag_physics,'acswupbcln'  ,acswupbcln  )
  call mpas_pool_get_array(diag_physics,'acswupt'     ,acswupt     )
  call mpas_pool_get_array(diag_physics,'acswuptc'    ,acswuptc    )
+ call mpas_pool_get_array(diag_physics,'acswuptcln'  ,acswuptcln  )
  call mpas_pool_get_array(diag_physics,'aclwdnb'     ,aclwdnb     )
  call mpas_pool_get_array(diag_physics,'aclwdnbc'    ,aclwdnbc    )
+ call mpas_pool_get_array(diag_physics,'aclwdnbcln'  ,aclwdnbcln  )
  call mpas_pool_get_array(diag_physics,'aclwdnt'     ,aclwdnt     )
  call mpas_pool_get_array(diag_physics,'aclwdntc'    ,aclwdntc    )
+ call mpas_pool_get_array(diag_physics,'aclwdntcln'  ,aclwdntcln  )
  call mpas_pool_get_array(diag_physics,'aclwupb'     ,aclwupb     )
  call mpas_pool_get_array(diag_physics,'aclwupbc'    ,aclwupbc    )
+ call mpas_pool_get_array(diag_physics,'aclwupbcln'  ,aclwupbcln  )
  call mpas_pool_get_array(diag_physics,'aclwupt'     ,aclwupt     )
  call mpas_pool_get_array(diag_physics,'aclwuptc'    ,aclwuptc    )
+ call mpas_pool_get_array(diag_physics,'aclwuptcln'  ,aclwuptcln  )
 
  call mpas_pool_get_array(diag_physics,'nsteps_accum',nsteps_accum)
  call mpas_pool_get_array(diag_physics,'ndays_accum' ,ndays_accum )
@@ -280,39 +308,55 @@ use mpas_stream_manager
     do iCell = 1, nCellsSolve
        i_acswdnb(iCell)  = 0
        i_acswdnbc(iCell) = 0
+       i_acswdnbcln(iCell) = 0
        i_acswdnt(iCell)  = 0
        i_acswdntc(iCell) = 0
+       i_acswdntcln(iCell) = 0
        i_acswupb(iCell)  = 0
        i_acswupbc(iCell) = 0
+       i_acswupbcln(iCell) = 0
        i_acswupt(iCell)  = 0
        i_acswuptc(iCell) = 0
+       i_acswuptcln(iCell) = 0
 
        i_aclwdnb(iCell)  = 0
        i_aclwdnbc(iCell) = 0
+       i_aclwdnbcln(iCell) = 0
        i_aclwdnt(iCell)  = 0
        i_aclwdntc(iCell) = 0
+       i_aclwdntcln(iCell) = 0
        i_aclwupb(iCell)  = 0
        i_aclwupbc(iCell) = 0
+       i_aclwupbcln(iCell) = 0
        i_aclwupt(iCell)  = 0
        i_aclwuptc(iCell) = 0
+       i_aclwuptcln(iCell) = 0
 
        acswdnb(iCell)  = 0._RKIND
        acswdnbc(iCell) = 0._RKIND
+       acswdnbcln(iCell) = 0._RKIND
        acswdnt(iCell)  = 0._RKIND
        acswdntc(iCell) = 0._RKIND
+       acswdntcln(iCell) = 0._RKIND
        acswupb(iCell)  = 0._RKIND
        acswupbc(iCell) = 0._RKIND
+       acswupbcln(iCell) = 0._RKIND
        acswupt(iCell)  = 0._RKIND
        acswuptc(iCell) = 0._RKIND
+       acswuptcln(iCell) = 0._RKIND
 
        aclwdnb(iCell)  = 0._RKIND
        aclwdnbc(iCell) = 0._RKIND
+       aclwdnbcln(iCell) = 0._RKIND
        aclwdnt(iCell)  = 0._RKIND
        aclwdntc(iCell) = 0._RKIND
+       aclwdntcln(iCell) = 0._RKIND
        aclwupb(iCell)  = 0._RKIND
        aclwupbc(iCell) = 0._RKIND
+       aclwupbcln(iCell) = 0._RKIND
        aclwupt(iCell)  = 0._RKIND
        aclwuptc(iCell) = 0._RKIND
+       aclwuptcln(iCell) = 0._RKIND
     enddo
  endif
 

--- a/src/core_atmosphere/physics/mpas_atmphys_manager.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_manager.F
@@ -152,7 +152,8 @@
                    config_sst_update,         &
                    config_gvf_update,         &
                    config_sstdiurn_update,    &
-                   config_deepsoiltemp_update
+                   config_deepsoiltemp_update,&
+                   config_calc_clean_atm_diag
 
  character(len=StrKIND),pointer:: config_convection_scheme, &
                                   config_radt_lw_scheme,    &
@@ -202,6 +203,7 @@
  call mpas_pool_get_config(domain%blocklist%configs,'config_sstdiurn_update'    ,config_sstdiurn_update    )
  call mpas_pool_get_config(domain%blocklist%configs,'config_deepsoiltemp_update',config_deepsoiltemp_update)
  call mpas_pool_get_config(domain%blocklist%configs,'config_dust_scheme'        ,config_dust_scheme        )
+ call mpas_pool_get_config(domain%blocklist%configs,'config_calc_clean_atm_diag', config_calc_clean_atm_diag)
 
 !update the current julian day and current year:
 
@@ -274,6 +276,7 @@
     endif
     call mpas_log_write('--- time to run the LW radiation scheme L_RADLW = $l',logicArgs=(/l_radtlw/))
  endif
+
 
  if(trim(config_radt_sw_scheme) /= "off") then
     l_radtsw = .false.
@@ -411,6 +414,7 @@
  logical,pointer:: config_sst_update
  logical,pointer:: config_frac_seaice
  logical,pointer:: config_microp_re
+ logical,pointer:: config_calc_clean_atm_diag
 
 
  integer,pointer:: cam_dim1
@@ -451,6 +455,7 @@
  call mpas_pool_get_config(configs,'config_microp_re'        ,config_microp_re        )
  call mpas_pool_get_config(configs,'config_smoke_scheme'     ,config_smoke_scheme     )
  call mpas_pool_get_config(configs,'config_dust_scheme'      ,config_dust_scheme      )
+ call mpas_pool_get_config(configs,'config_calc_clean_atm_diag', config_calc_clean_atm_diag)
 
  call mpas_get_timeInterval(mpas_get_clock_timestep(clock, ierr), dt=dt)
 

--- a/src/core_atmosphere/physics/mpas_atmphys_update.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_update.F
@@ -87,15 +87,22 @@
                                   i_aclwdnb,i_aclwdnbc,i_aclwdnt,i_aclwdntc, &
                                   i_aclwupb,i_aclwupbc,i_aclwupt,i_aclwuptc
 
+ integer,dimension(:),pointer  :: i_acswdnbcln,i_acswdntcln,i_acswupbcln, &
+                                  i_acswuptcln,i_aclwdnbcln,i_aclwdntcln, &
+                                  i_aclwupbcln,i_aclwuptcln
  real(kind=RKIND),pointer:: bucket_radt
  real(kind=RKIND),dimension(:),pointer:: swdnb,swdnbc,swdnt,swdntc,  &
                                          swupb,swupbc,swupt,swuptc,  &
                                          lwdnb,lwdnbc,lwdnt,lwdntc,  &
                                          lwupb,lwupbc,lwupt,lwuptc
+ real(kind=RKIND),dimension(:),pointer:: swdnbcln,swdntcln,swupbcln,swuptcln,&
+                                         lwdnbcln,lwdntcln,lwupbcln,lwuptcln
  real(kind=RKIND),dimension(:),pointer:: acswdnb,acswdnbc,acswdnt,acswdntc,  &
                                          acswupb,acswupbc,acswupt,acswuptc,  &
                                          aclwdnb,aclwdnbc,aclwdnt,aclwdntc,  &
                                          aclwupb,aclwupbc,aclwupt,aclwuptc
+ real(kind=RKIND),dimension(:),pointer:: acswdnbcln,acswdntcln,acswupbcln,acswuptcln,  &
+                                         aclwdnbcln,aclwdntcln,aclwupbcln,aclwuptcln
 
 !local variables and arrays:
  integer:: iCell
@@ -108,74 +115,106 @@
 
  call mpas_pool_get_array(diag_physics,'i_acswdnb' , i_acswdnb )
  call mpas_pool_get_array(diag_physics,'i_acswdnbc', i_acswdnbc)
+ call mpas_pool_get_array(diag_physics,'i_acswdnbcln', i_acswdnbcln)
  call mpas_pool_get_array(diag_physics,'i_acswdnt' , i_acswdnt )
  call mpas_pool_get_array(diag_physics,'i_acswdntc', i_acswdntc)
+ call mpas_pool_get_array(diag_physics,'i_acswdntcln', i_acswdntcln)
  call mpas_pool_get_array(diag_physics,'i_acswupb' , i_acswupb )
  call mpas_pool_get_array(diag_physics,'i_acswupbc', i_acswupbc)
+ call mpas_pool_get_array(diag_physics,'i_acswupbcln', i_acswupbcln)
  call mpas_pool_get_array(diag_physics,'i_acswupt' , i_acswupt )
  call mpas_pool_get_array(diag_physics,'i_acswuptc', i_acswuptc)
+ call mpas_pool_get_array(diag_physics,'i_acswuptcln', i_acswuptcln)
  call mpas_pool_get_array(diag_physics,'i_aclwdnb' , i_aclwdnb )
  call mpas_pool_get_array(diag_physics,'i_aclwdnbc', i_aclwdnbc)
+ call mpas_pool_get_array(diag_physics,'i_aclwdnbcln', i_aclwdnbcln)
  call mpas_pool_get_array(diag_physics,'i_aclwdnt' , i_aclwdnt )
  call mpas_pool_get_array(diag_physics,'i_aclwdntc', i_aclwdntc)
+ call mpas_pool_get_array(diag_physics,'i_aclwdntcln', i_aclwdntcln)
  call mpas_pool_get_array(diag_physics,'i_aclwupb' , i_aclwupb )
  call mpas_pool_get_array(diag_physics,'i_aclwupbc', i_aclwupbc)
+ call mpas_pool_get_array(diag_physics,'i_aclwupbcln', i_aclwupbcln)
  call mpas_pool_get_array(diag_physics,'i_aclwupt' , i_aclwupt )
  call mpas_pool_get_array(diag_physics,'i_aclwuptc', i_aclwuptc)
+ call mpas_pool_get_array(diag_physics,'i_aclwuptcln', i_aclwuptcln)
 
  call mpas_pool_get_array(diag_physics,'acswdnb'   , acswdnb   )
  call mpas_pool_get_array(diag_physics,'acswdnbc'  , acswdnbc  )
+ call mpas_pool_get_array(diag_physics,'acswdnbcln', acswdnbcln)
  call mpas_pool_get_array(diag_physics,'acswdnt'   , acswdnt   )
  call mpas_pool_get_array(diag_physics,'acswdntc'  , acswdntc  )
+ call mpas_pool_get_array(diag_physics,'acswdntcln', acswdntcln)
  call mpas_pool_get_array(diag_physics,'acswupb'   , acswupb   )
  call mpas_pool_get_array(diag_physics,'acswupbc'  , acswupbc  )
+ call mpas_pool_get_array(diag_physics,'acswupbcln', acswupbcln)
  call mpas_pool_get_array(diag_physics,'acswupt'   , acswupt   )
  call mpas_pool_get_array(diag_physics,'acswuptc'  , acswuptc  )
+ call mpas_pool_get_array(diag_physics,'acswuptcln', acswuptcln)
  call mpas_pool_get_array(diag_physics,'aclwdnb'   , aclwdnb   )
  call mpas_pool_get_array(diag_physics,'aclwdnbc'  , aclwdnbc  )
+ call mpas_pool_get_array(diag_physics,'aclwdnbcln', aclwdnbcln)
  call mpas_pool_get_array(diag_physics,'aclwdnt'   , aclwdnt   )
  call mpas_pool_get_array(diag_physics,'aclwdntc'  , aclwdntc  )
+ call mpas_pool_get_array(diag_physics,'aclwdntcln', aclwdntcln)
  call mpas_pool_get_array(diag_physics,'aclwupb'   , aclwupb   )
  call mpas_pool_get_array(diag_physics,'aclwupbc'  , aclwupbc  )
+ call mpas_pool_get_array(diag_physics,'aclwupbcln', aclwupbcln)
  call mpas_pool_get_array(diag_physics,'aclwupt'   , aclwupt   )
  call mpas_pool_get_array(diag_physics,'aclwuptc'  , aclwuptc  )
+ call mpas_pool_get_array(diag_physics,'aclwuptcln', aclwuptcln)
 
  call mpas_pool_get_array(diag_physics,'swdnb'     , swdnb     )
  call mpas_pool_get_array(diag_physics,'swdnbc'    , swdnbc    )
+ call mpas_pool_get_array(diag_physics,'swdnbcln'  , swdnbcln  )
  call mpas_pool_get_array(diag_physics,'swdnt'     , swdnt     )
  call mpas_pool_get_array(diag_physics,'swdntc'    , swdntc    )
+ call mpas_pool_get_array(diag_physics,'swdntcln'  , swdntcln  )
  call mpas_pool_get_array(diag_physics,'swupb'     , swupb     )
  call mpas_pool_get_array(diag_physics,'swupbc'    , swupbc    )
+ call mpas_pool_get_array(diag_physics,'swupbcln'  , swupbcln  )
  call mpas_pool_get_array(diag_physics,'swupt'     , swupt     )
  call mpas_pool_get_array(diag_physics,'swuptc'    , swuptc    )
+ call mpas_pool_get_array(diag_physics,'swuptcln'  , swuptcln  )
  call mpas_pool_get_array(diag_physics,'lwdnb'     , lwdnb     )
  call mpas_pool_get_array(diag_physics,'lwdnbc'    , lwdnbc    )
+ call mpas_pool_get_array(diag_physics,'lwdnbcln'  , lwdnbcln  )
  call mpas_pool_get_array(diag_physics,'lwdnt'     , lwdnt     )
  call mpas_pool_get_array(diag_physics,'lwdntc'    , lwdntc    )
+ call mpas_pool_get_array(diag_physics,'lwdntcln'  , lwdntcln  )
  call mpas_pool_get_array(diag_physics,'lwupb'     , lwupb     )
  call mpas_pool_get_array(diag_physics,'lwupbc'    , lwupbc    )
+ call mpas_pool_get_array(diag_physics,'lwupbcln'  , lwupbcln  )
  call mpas_pool_get_array(diag_physics,'lwupt'     , lwupt     )
  call mpas_pool_get_array(diag_physics,'lwuptc'    , lwuptc    )
+ call mpas_pool_get_array(diag_physics,'lwuptcln'  , lwuptcln  )
 
  do iCell = its, ite
     !short-wave radiation:
     acswdnb(iCell)  = acswdnb (iCell) + swdnb (iCell)*dt_dyn
     acswdnbc(iCell) = acswdnbc(iCell) + swdnbc(iCell)*dt_dyn
+    acswdnbcln(iCell) = acswdnbcln(iCell) + swdnbcln(iCell)*dt_dyn
     acswdnt(iCell)  = acswdnt (iCell) + swdnt (iCell)*dt_dyn
     acswdntc(iCell) = acswdntc(iCell) + swdntc(iCell)*dt_dyn
+    acswdntcln(iCell) = acswdntcln(iCell) + swdntcln(iCell)*dt_dyn
     acswupb(iCell)  = acswupb (iCell) + swupb (iCell)*dt_dyn
     acswupbc(iCell) = acswupbc(iCell) + swupbc(iCell)*dt_dyn
+    acswupbcln(iCell) = acswupbcln(iCell) + swupbcln(iCell)*dt_dyn
     acswupt(iCell)  = acswupt (iCell) + swupt (iCell)*dt_dyn
     acswuptc(iCell) = acswuptc(iCell) + swuptc(iCell)*dt_dyn
+    acswuptcln(iCell) = acswuptcln(iCell) + swuptcln(iCell)*dt_dyn
     !long-wave radiation:
     aclwdnb(iCell)  = aclwdnb (iCell) + lwdnb (iCell)*dt_dyn
     aclwdnbc(iCell) = aclwdnbc(iCell) + lwdnbc(iCell)*dt_dyn
+    aclwdnbcln(iCell) = aclwdnbcln(iCell) + lwdnbcln(iCell)*dt_dyn
     aclwdnt(iCell)  = aclwdnt (iCell) + lwdnt (iCell)*dt_dyn
     aclwdntc(iCell) = aclwdntc(iCell) + lwdntc(iCell)*dt_dyn
+    aclwdntcln(iCell) = aclwdntcln(iCell) + lwdntcln(iCell)*dt_dyn
     aclwupb(iCell)  = aclwupb (iCell) + lwupb (iCell)*dt_dyn
     aclwupbc(iCell) = aclwupbc(iCell) + lwupbc(iCell)*dt_dyn
+    aclwupbcln(iCell) = aclwupbcln(iCell) + lwupbcln(iCell)*dt_dyn
     aclwupt(iCell)  = aclwupt (iCell) + lwupt (iCell)*dt_dyn
     aclwuptc(iCell) = aclwuptc(iCell) + lwuptc(iCell)*dt_dyn
+    aclwuptcln(iCell) = aclwuptcln(iCell) + lwuptcln(iCell)*dt_dyn
  enddo
 
  if(l_acradt .and. bucket_radt.gt.0._RKIND) then
@@ -190,6 +229,10 @@
           i_acswdnbc(iCell) = i_acswdnbc(iCell) + 1
           acswdnbc(iCell) = acswdnbc(iCell) - bucket_radt
        endif   
+       if(acswdnbcln(iCell) .gt. bucket_radt) then
+          i_acswdnbcln(iCell) = i_acswdnbcln(iCell) + 1
+          acswdnbcln(iCell) = acswdnbcln(iCell) - bucket_radt
+       endif   
        if(acswdnt(iCell) .gt. bucket_radt) then
           i_acswdnt(iCell) = i_acswdnt(iCell) + 1
           acswdnt(iCell) = acswdnt(iCell) - bucket_radt
@@ -197,6 +240,10 @@
        if(acswdntc(iCell) .gt. bucket_radt) then
           i_acswdntc(iCell) = i_acswdntc(iCell) + 1
           acswdntc(iCell) = acswdntc(iCell) - bucket_radt
+       endif
+       if(acswdntcln(iCell) .gt. bucket_radt) then
+          i_acswdntcln(iCell) = i_acswdntcln(iCell) + 1
+          acswdntcln(iCell) = acswdntcln(iCell) - bucket_radt
        endif
        if(acswupb(iCell) .gt. bucket_radt) then
           i_acswupb(iCell) = i_acswupb(iCell) + 1
@@ -206,6 +253,10 @@
           i_acswupbc(iCell) = i_acswupbc(iCell) + 1
           acswupbc(iCell) = acswupbc(iCell) - bucket_radt
        endif   
+       if(acswupbcln(iCell) .gt. bucket_radt) then
+          i_acswupbcln(iCell) = i_acswupbcln(iCell) + 1
+          acswupbcln(iCell) = acswupbcln(iCell) - bucket_radt
+       endif   
        if(acswupt(iCell) .gt. bucket_radt) then
           i_acswupt(iCell) = i_acswupt(iCell) + 1
           acswupt(iCell) = acswupt(iCell) - bucket_radt
@@ -213,6 +264,10 @@
        if(acswuptc(iCell) .gt. bucket_radt) then
           i_acswuptc(iCell) = i_acswuptc(iCell) + 1
           acswuptc(iCell) = acswuptc(iCell) - bucket_radt
+       endif
+       if(acswuptcln(iCell) .gt. bucket_radt) then
+          i_acswuptcln(iCell) = i_acswuptcln(iCell) + 1
+          acswuptcln(iCell) = acswuptcln(iCell) - bucket_radt
        endif
        !long-wave radiation:
        if(aclwdnb(iCell) .gt. bucket_radt) then
@@ -223,6 +278,10 @@
           i_aclwdnbc(iCell) = i_aclwdnbc(iCell) + 1
           aclwdnbc(iCell) = aclwdnbc(iCell) - bucket_radt
        endif   
+       if(aclwdnbcln(iCell) .gt. bucket_radt) then
+          i_aclwdnbcln(iCell) = i_aclwdnbcln(iCell) + 1
+          aclwdnbcln(iCell) = aclwdnbcln(iCell) - bucket_radt
+       endif   
        if(aclwdnt(iCell) .gt. bucket_radt) then
           i_aclwdnt(iCell) = i_aclwdnt(iCell) + 1
           aclwdnt(iCell) = aclwdnt(iCell) - bucket_radt
@@ -230,6 +289,10 @@
        if(aclwdntc(iCell) .gt. bucket_radt) then
           i_aclwdntc(iCell) = i_aclwdntc(iCell) + 1
           aclwdntc(iCell) = aclwdntc(iCell) - bucket_radt
+       endif
+       if(aclwdntcln(iCell) .gt. bucket_radt) then
+          i_aclwdntcln(iCell) = i_aclwdntcln(iCell) + 1
+          aclwdntcln(iCell) = aclwdntcln(iCell) - bucket_radt
        endif
        if(aclwupb(iCell) .gt. bucket_radt) then
           i_aclwupb(iCell) = i_aclwupb(iCell) + 1
@@ -239,6 +302,10 @@
           i_aclwupbc(iCell) = i_aclwupbc(iCell) + 1
           aclwupbc(iCell) = aclwupbc(iCell) - bucket_radt
        endif   
+       if(aclwupbcln(iCell) .gt. bucket_radt) then
+          i_aclwupbcln(iCell) = i_aclwupbcln(iCell) + 1
+          aclwupbcln(iCell) = aclwupbcln(iCell) - bucket_radt
+       endif   
        if(aclwupt(iCell) .gt. bucket_radt) then
           i_aclwupt(iCell) = i_aclwupt(iCell) + 1
           aclwupt(iCell) = aclwupt(iCell) - bucket_radt
@@ -246,6 +313,10 @@
        if(aclwuptc(iCell) .gt. bucket_radt) then
           i_aclwuptc(iCell) = i_aclwuptc(iCell) + 1
           aclwuptc(iCell) = aclwuptc(iCell) - bucket_radt
+       endif
+       if(aclwuptcln(iCell) .gt. bucket_radt) then
+          i_aclwuptcln(iCell) = i_aclwuptcln(iCell) + 1
+          aclwuptcln(iCell) = aclwuptcln(iCell) - bucket_radt
        endif
     enddo
 

--- a/src/core_atmosphere/physics/mpas_atmphys_vars.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_vars.F
@@ -872,12 +872,16 @@
     swcf_p,           &!shortwave cloud forcing at top-of-atmosphere                        [W m-2]
     swdnb_p,          &!all-sky downwelling shortwave flux at bottom-of-atmosphere          [J m-2]
     swdnbc_p,         &!clear-sky downwelling shortwave flux at bottom-of-atmosphere        [J m-2]
+    swdnbcln_p,       &!clean-sky downwelling shortwave flux at bottom-of-atmosphere        [J m-2]
     swdnt_p,          &!all-sky downwelling shortwave flux at top-of-atmosphere             [J m-2]
     swdntc_p,         &!clear-sky downwelling shortwave flux at top-of-atmosphere           [J m-2]
+    swdntcln_p,       &!clean-sky downwelling shortwave flux at top-of-atmosphere           [J m-2]
     swupb_p,          &!all-sky upwelling shortwave flux at bottom-of-atmosphere            [J m-2]
     swupbc_p,         &!clear-sky upwelling shortwave flux at bottom-of-atmosphere          [J m-2]
+    swupbcln_p,       &!clean-sky upwelling shortwave flux at bottom-of-atmosphere          [J m-2]
     swupt_p,          &!all-sky upwelling shortwave flux at top-of-atmosphere               [J m-2]
-    swuptc_p           !clear-sky upwelling shortwave flux at top-of-atmosphere             [J m-2]
+    swuptc_p,         &!clear-sky upwelling shortwave flux at top-of-atmosphere             [J m-2]
+    swuptcln_p         !clean-sky upwelling shortwave flux at top-of-atmosphere             [J m-2]
 
  real(kind=RKIND),dimension(:,:),allocatable:: &
     swvisdir_p,       &!visible direct downward flux                                        [W m-2]
@@ -893,12 +897,14 @@
  real(kind=RKIND),dimension(:,:,:),allocatable:: &
     swdnflx_p,        &!
     swdnflxc_p,       &!
+    swdnflxcln_p,     &!
     swupflx_p,        &!
-    swupflxc_p         !
+    swupflxc_p,       &!
+    swupflxcln_p       !
 
  real(kind=RKIND),dimension(:,:,:),allocatable:: &
-    rthratensw_p       !uncoupled theta tendency due to shortwave radiation                 [K s-1]
-
+    rthratensw_p   !, & !uncoupled theta tendency due to shortwave radiation                 [K s-1]
+!    rthratenswc_p  !uncoupled theta tendency due to clear-sky shortwave radiation        [K s-1]
 !=================================================================================================================
 !... variables and arrays related to parameterization of long-wave radiation:
 !=================================================================================================================
@@ -913,22 +919,29 @@
     lwcf_p,           &!longwave cloud forcing at top-of-atmosphere                         [W m-2]
     lwdnb_p,          &!all-sky downwelling longwave flux at bottom-of-atmosphere           [J m-2]
     lwdnbc_p,         &!clear-sky downwelling longwave flux at bottom-of-atmosphere         [J m-2]
+    lwdnbcln_p,       &!clean-sky downwelling longwave flux at bottom-of-atmosphere         [J m-2]
     lwdnt_p,          &!all-sky downwelling longwave flux at top-of-atmosphere              [J m-2]
     lwdntc_p,         &!clear-sky downwelling longwave flux at top-of-atmosphere            [J m-2]
+    lwdntcln_p,       &!clean-sky downwelling longwave flux at top-of-atmosphere            [J m-2]
     lwupb_p,          &!all-sky upwelling longwave flux at bottom-of-atmosphere             [J m-2]
     lwupbc_p,         &!clear-sky upwelling longwave flux at bottom-of-atmosphere           [J m-2]
+    lwupbcln_p,       &!clean-sky upwelling longwave flux at bottom-of-atmosphere           [J m-2]
     lwupt_p,          &!all-sky upwelling longwave flux at top-of-atmosphere                [J m-2]
     lwuptc_p,         &!clear-sky upwelling longwave flux at top-of-atmosphere              [J m-2]
+    lwuptcln_p,       &!clean-sky upwelling longwave flux at top-of-atmosphere              [J m-2]
     olrtoa_p           !outgoing longwave radiation at top-of-the-atmosphere                [W m-2]
 
   real(kind=RKIND),dimension(:,:,:),allocatable:: &
     lwdnflx_p,        &!
     lwdnflxc_p,       &!
+    lwdnflxcln_p,     &!
     lwupflx_p,        &!
-    lwupflxc_p         !
+    lwupflxc_p,       &!
+    lwupflxcln_p      !
 
  real(kind=RKIND),dimension(:,:,:),allocatable:: &
     rthratenlw_p,     &!uncoupled theta tendency due to longwave radiation                  [K s-1]
+    rthratenlwc_p,     &!uncoupled theta tendency due to clear-sky longwave radiation                  [K s-1]
     rrecloud_p,       &!effective radius for cloud water calculated in rrtmg_lwrad             [mu]
     rreice_p,         &!effective radius for cloud ice calculated in rrmtg_lwrad               [mu]
     rresnow_p         !effective radius for snow calculated in rrtmg_lwrad                    [mu]

--- a/src/core_atmosphere/physics/physics_wrf/module_ra_rrtmg_lw.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_ra_rrtmg_lw.F
@@ -10711,7 +10711,7 @@ contains
              taucmcl ,ciwpmcl ,clwpmcl , cswpmcl ,reicmcl ,relqmcl , resnmcl , &
              tauaer  , &
              uflx    ,dflx    ,hr      ,uflxc   ,dflxc,  hrc, &
-             uflxcln ,dflxcln, calc_clean_atm_diag )
+             uflxcln ,dflxcln, config_calc_clean_atm_diag )
 
 ! -------- Description --------
 
@@ -10894,7 +10894,7 @@ contains
                                                       !    Dimensions: (ncol,nlay,nbndlw)
                                                       !   for future expansion 
                                                       !   (lw aerosols/scattering not yet available)
-      integer, intent(in) :: calc_clean_atm_diag      ! Control for clean air diagnositic calls for WRF-Chem
+      logical, intent(in) :: config_calc_clean_atm_diag      ! Control for clean air diagnositic calls for WRF-Chem
 
 ! ----- Output -----
 
@@ -11144,12 +11144,11 @@ contains
 ! to be used.  Clear sky calculation is done simultaneously.
 ! For McICA, RTRNMC is called for clear and cloudy calculations.
 
-#if (WRF_CHEM == 1)
         ! Call the radiative transfer routine for "clean" sky first,
         ! passing taug rather than taut so we have no aerosol influence.
         ! We will keep totuclnlfl, totdclnlfl, fnetcln, and htrcln,
         ! and then overwrite the rest with the second call to rtrnmc.
-         if(calc_clean_atm_diag .gt. 0)then
+         if(config_calc_clean_atm_diag)then
              call rtrnmc(nlayers, istart, iend, iout, pz, semiss, ncbands, &
                      cldfmc, taucmc, planklay, planklev, plankbnd, &
                      pwvcm, fracs, taug, &
@@ -11161,12 +11160,6 @@ contains
                 totdclnlfl(k) = 0.0
             end do
          end if
-#else
-         do k = 0, nlayers
-            totuclnlfl(k) = 0.0
-            totdclnlfl(k) = 0.0
-         end do
-#endif
          call rtrnmc(nlayers, istart, iend, iout, pz, semiss, ncbands, &
                      cldfmc, taucmc, planklay, planklev, plankbnd, &
                      pwvcm, fracs, taut, &
@@ -11576,12 +11569,13 @@ CONTAINS
                        qi3d,qs3d,qg3d,cldfra3d,o33d,tsk,emiss,    &
                        xland,xice,snow,xlat,julday,icloud,        &
                        cldovrlp,idcor,o3input,noznlevels,         &
-                       pin,o3clim,glw,olr,lwcf,rthratenlw,        &
+                       pin,o3clim,glw,olr,lwcf,rthratenlw,rthratenlwc, &
                        has_reqc,has_reqi,has_reqs,re_cloud,       &
                        re_ice,re_snow,rre_cloud,rre_ice,rre_snow, &
-                       lwupt,lwuptc,lwdnt,lwdntc,                 &
-                       lwupb,lwupbc,lwdnb,lwdnbc,                 &
+                       lwupt,lwuptc,lwuptcln,lwdnt,lwdntc,lwdntcln,&
+                       lwupb,lwupbc,lwupbcln,lwdnb,lwdnbc,lwdnbcln,&
                        lwupflx, lwupflxc, lwdnflx, lwdnflxc,      &
+                       config_calc_clean_atm_diag,                 & 
                        ids,ide, jds,jde, kds,kde,                 & 
                        ims,ime, jms,jme, kms,kme,                 &
                        its,ite, jts,jte, kts,kte                  &
@@ -11601,6 +11595,7 @@ CONTAINS
  integer,intent(in),optional:: o3input
 
  real,intent(in),dimension(ims:ime,jms:jme):: emiss,tsk,snow,xice,xland,xlat
+ logical,intent(in),optional:: config_calc_clean_atm_diag
 
  real,intent(in),dimension(ims:ime,kms:kme,jms:jme):: t3d,p3d,pi3d
  real,intent(in),dimension(ims:ime,kms:kme,jms:jme):: dz8w,p8w,t8w
@@ -11617,9 +11612,9 @@ CONTAINS
 !--- inout arguments:
  real,intent(inout),dimension(ims:ime,jms:jme):: glw,olr,lwcf
  real,intent(inout),dimension(ims:ime,jms:jme),optional:: &
-    lwupt,lwuptc,lwdnt,lwdntc,lwupb,lwupbc,lwdnb,lwdnbc
+    lwupt,lwuptc,lwdnt,lwdntc,lwupb,lwupbc,lwdnb,lwdnbc,lwuptcln,lwdntcln,lwupbcln,lwdnbcln
 
- real,intent(inout),dimension(ims:ime,kms:kme,jms:jme):: rthratenlw
+ real,intent(inout),dimension(ims:ime,kms:kme,jms:jme):: rthratenlw,rthratenlwc
  
 !--- output arguments:
   real,intent(out),dimension(ims:ime,kms:kme,jms:jme),optional:: &
@@ -11628,7 +11623,7 @@ CONTAINS
      lwupflx,lwupflxc,lwdnflx,lwdnflxc
 
 !local variables and arrays:
- integer:: calc_clean_atm_diag
+! integer:: config_calc_clean_atm_diag
  integer:: nb,ncol,nlay,icld,inflglw,iceflglw,liqflglw
  integer:: iplon,irng,permuteseed
  integer:: pcols,pver
@@ -11759,7 +11754,7 @@ CONTAINS
  liqflglw = 1
 
 !--- initialize option for the calculation of clean air upward and downward fluxes:
- calc_clean_atm_diag = 0
+! config_calc_clean_atm_diag = 0
 
 !--- latitude loop:
  j_loop: do j = jts,jte
@@ -12205,7 +12200,7 @@ CONTAINS
                    emis    , inflglw , iceflglw , liqflglw , cldfmcl  , taucmcl , & 
                    ciwpmcl , clwpmcl , cswpmcl  , reicmcl  , relqmcl  , resnmcl , &
                    tauaer  , uflx    , dflx     , hr       , uflxc    , dflxc   , &
-                   hrc     , uflxcln , dflxcln  , calc_clean_atm_diag)
+                   hrc     , uflxcln , dflxcln  , config_calc_clean_atm_diag)
 
 
 
@@ -12225,11 +12220,22 @@ CONTAINS
           lwupbc(i,j) = uflxc(1,1)
           lwdnb(i,j)  = dflx(1,1)
           lwdnbc(i,j) = dflxc(1,1)
+          ! Directly copied from the WRFv4.6 physics (RRTMG LW)
+          ! Minsu Choi CIRES/NOAA GSL
+          !Output up and down toa fluxes for clean sky
+          if(config_calc_clean_atm_diag)then
+            lwuptcln(i,j)  = uflxcln(1,nlayers+1)
+            lwdntcln(i,j)  = dflxcln(1,nlayers+1)
+            !Output up and down surface fluxes for clean sky
+            lwupbcln(i,j)  = uflxcln(1,1)
+            lwdnbcln(i,j)  = dflxcln(1,1)
+          endif
        endif
 
        if(present(lwupflx)) then
           !output up and down fluxes:
-          do k=kts,nlayers+1
+!          do k=kts,nlayers+1
+          do k=kts,kte+2
              lwupflx(i,k,j)  = uflx(1,k)
              lwupflxc(i,k,j) = uflxc(1,k)
              lwdnflx(i,k,j)  = dflx(1,k)
@@ -12241,6 +12247,8 @@ CONTAINS
        do k = kts, kte
           tten1d(k) = hr(ncol,k)/86400.
           rthratenlw(i,k,j) = tten1d(k)/pi3d(i,k,j)
+          tten1d(k) = hrc(ncol,k)/86400.
+          rthratenlwc(i,k,j) = tten1d(k)/pi3d(i,k,j)
        enddo
 
        !--- output the effective radii for cloud water, cloud ice, and snow:

--- a/src/core_atmosphere/physics/physics_wrf/module_ra_rrtmg_sw.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_ra_rrtmg_sw.F
@@ -8881,9 +8881,8 @@
 ! ----------------------  End,  Zhenxin 2011-06-20    --------------------------------!
              swdkdir,swdkdif,                               & ! jararias, 2013/08/10
              swdkdirc,                                      & ! PAJ
-             calc_clean_atm_diag                            &
+             config_calc_clean_atm_diag                            &
                                                                 )
-
 
 ! ------- Description -------
 
@@ -9080,7 +9079,7 @@
       real(kind=rb), intent(in) :: ecaer(:,:,:)       ! Aerosol optical depth at 0.55 micron (iaer=6 only)
                                                       !    Dimensions: (ncol,nlay,naerec)
                                                       ! (non-delta scaled)      
-      integer, intent(in)       :: calc_clean_atm_diag! Control for clean air diagnositic calls for WRF-Chem
+      logical, intent(in)       :: config_calc_clean_atm_diag! Control for clean air diagnositic calls for WRF-Chem
 
 ! ----- Output -----
 
@@ -9269,6 +9268,8 @@
       real(kind=rb) :: swnflxc(nlay+2)        ! Clear sky shortwave net flux (W/m2)
       real(kind=rb) :: dirdflux(nlay+2)       ! Direct downward shortwave surface flux
       real(kind=rb) :: difdflux(nlay+2)       ! Diffuse downward shortwave surface flux
+      real(kind=rb) :: dirdcflux(nlay+2)      ! Clear sky direct downward shortwave flux
+      real(kind=rb) :: difdcflux(nlay+2)      ! Clear sky diffuse downward shortwave flux
       real(kind=rb) :: uvdflx(nlay+2)         ! Total sky downward shortwave flux, UV/vis  
       real(kind=rb) :: nidflx(nlay+2)         ! Total sky downward shortwave flux, near-IR 
       real(kind=rb) :: dirdnuv(nlay+2)        ! Direct downward shortwave flux, UV/vis
@@ -9564,10 +9565,9 @@
          swhrc(iplon,nlayers) = 0._rb
          swhr(iplon,nlayers) = 0._rb
 
-#if (WRF_CHEM == 1)
          !  Repeat call to 2-stream radiation model using "clean sky"
          !  variables and aerosol tau set to 0
-         if(calc_clean_atm_diag .gt. 0)then
+         if(config_calc_clean_atm_diag)then
             do i=1,nlayers+1
                 zbbcu(i) = 0._rb
                 zbbcd(i) = 0._rb
@@ -9607,14 +9607,6 @@
                swdflxcln(iplon,i) = 0.0
             enddo
          end if
-
-#else
-         do i = 1, nlayers+1
-            swuflxcln(iplon,i) = 0.0
-            swdflxcln(iplon,i) = 0.0
-         enddo
-
-#endif
 ! End longitude loop
       enddo
 
@@ -10030,13 +10022,14 @@ CONTAINS
                        degrad,declin,solcon,xlat,xlong,icloud,         &
                        cldovrlp,idcor,o3input, &
                        noznlevels,pin,o3clim,gsw,swcf,rthratensw,      &
-                       has_reqc,has_reqi,has_reqs,re_cloud,            &
+                       has_reqc,has_reqi,has_reqs,re_cloud,&
                        re_ice,re_snow,                                 &
                        aer_opt,tauaer3d,ssaaer3d,asyaer3d,             &
-                       swupt,swuptc,swdnt,swdntc,                      &
-                       swupb,swupbc,swdnb,swdnbc,                      &
-                       swupflx, swupflxc, swdnflx, swdnflxc,           &
-                       swddir,swddni,swddif,                           &
+                       swupt,swuptc,swuptcln,swdnt,swdntc,swdntcln,    &
+                       swupb,swupbc,swupbcln,swdnb,swdnbc,swdnbcln,    &
+                       swupflx, swupflxc,swupflxcln, swdnflx,          &
+                       swdnflxc,swdnflxcln,                            &
+                       swddir,swddni,swddif,config_calc_clean_atm_diag,       &
                        ids,ide, jds,jde, kds,kde,                      & 
                        ims,ime, jms,jme, kms,kme,                      &
                        its,ite, jts,jte, kts,kte                       &
@@ -10079,9 +10072,11 @@ CONTAINS
 !--- inout arguments:
  real,intent(inout),dimension(ims:ime,jms:jme):: coszr,gsw,swcf
  real,intent(inout),dimension(ims:ime,jms:jme),optional:: &
-    swupt,swuptc,swdnt,swdntc,swupb,swupbc,swdnb,swdnbc
+    swupt,swuptc,swuptcln,swdnt,swdntc,swdntcln,swupb,swupbc,swupbcln,swdnb,swdnbc,swdnbcln
+ real,intent(inout),dimension(ims:ime,jms:jme),optional:: swupflxcln, swdnflxcln
 
- real,intent(inout),dimension(ims:ime,kms:kme,jms:jme):: rthratensw
+ real,intent(inout),dimension(ims:ime,kms:kme,jms:jme)::rthratensw !,rthratenswc
+
 
 !--- output arguments:
   real,intent(out),dimension(ims:ime,jms:jme),optional:: &
@@ -10092,7 +10087,7 @@ CONTAINS
 !local variables and arrays:
  logical:: dorrsw
 
- integer:: calc_clean_atm_diag
+ logical, intent(in):: config_calc_clean_atm_diag
  integer:: na,nb,ncol,nlay,icld,inflgsw,iceflgsw,liqflgsw
  integer:: dyofyr
  integer:: iplon,irng,permuteseed
@@ -10187,7 +10182,7 @@ CONTAINS
  liqflgsw = 1
 
 !--- initialize option for the calculation of clean air upward and downward fluxes:
- calc_clean_atm_diag = 0
+! config_calc_clean_atm_diag = 0
 
 !--- latitude loop:
  j_loop: do j = jts,jte
@@ -10600,7 +10595,7 @@ CONTAINS
                       tauaer    , ssaaer    , asmaer    , ecaer     , swuflx    , swdflx    , &
                       swhr      , swuflxc   , swdflxc   , swhrc     , swuflxcln , swdflxcln , &
                       aer_opt   , sibvisdir , sibvisdif , sibnirdir , sibnirdif , swdkdir   , &
-                      swdkdif   , swdkdirc  , calc_clean_atm_diag)
+                      swdkdif   , swdkdirc  , config_calc_clean_atm_diag)
 
           !--- OUTPUTS:
           gsw(i,j)  = swdflx(1,1) - swuflx(1,1)
@@ -10617,6 +10612,13 @@ CONTAINS
              swupbc(i,j) = swuflxc(1,1)
              swdnb(i,j)  = swdflx(1,1)
              swdnbc(i,j) = swdflxc(1,1)
+             ! Clean diagnostics, Minsu Choi CIRES/NOAA GSL
+            if(config_calc_clean_atm_diag)then
+               swuptcln(i,j)  = swuflxcln(1,kte+2)
+               swdntcln(i,j)  = swdflxcln(1,kte+2)
+               swupbcln(i,j)  = swuflxcln(1,1)
+               swdnbcln(i,j)  = swdflxcln(1,1)
+            end if
           endif
 
           if(present(swddir) .and. present(swddni) .and. present(swddif)) then
@@ -10638,6 +10640,8 @@ CONTAINS
           do k = kts, kte 
              tten1d(k) = swhr(ncol,k)/86400.
              rthratensw(i,k,j) = tten1d(k)/pi3d(i,k,j)
+!             tten1d(k) = swhrc(ncol,k)/86400.
+!             rthratenswc(i,k,j) = tten1d(k)/pi3d(i,k,j)
           enddo
 
        else
@@ -10653,6 +10657,12 @@ CONTAINS
              swupbc(i,j)    = 0.
              swdnb(i,j)     = 0.
              swdnbc(i,j)    = 0.
+             if(config_calc_clean_atm_diag)then
+               swuptcln(i,j)  = 0.
+               swdntcln(i,j)  = 0.
+               swupbcln(i,j)  = 0.
+               swdnbcln(i,j)  = 0.
+             end if
           endif
 
        endif

--- a/src/core_atmosphere/physics/registry.chemistry.xml
+++ b/src/core_atmosphere/physics/registry.chemistry.xml
@@ -178,6 +178,7 @@
               runtime_format="separate_file">
 	      <var name="swdnb"/>
               <var name="swdnbc"/>
+              <var name="swdnbcln"/>
               <var name="aod3d_smoke"/>
               <var name="aod3d"/>
               <var name="aod550"/>

--- a/src/core_init_atmosphere/Registry.xml
+++ b/src/core_init_atmosphere/Registry.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<registry model="mpas" core="init_atmosphere" core_abbrev="init_atm" version="8.3.1-2.1">
+<registry model="mpas" core="init_atmosphere" core_abbrev="init_atm" version="8.3.0-2.0">
 
 <!-- **************************************************************************************** -->
 <!-- ************************************** Dimensions ************************************** -->

--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -8361,6 +8361,7 @@ call mpas_log_write('Done with soil consistency check')
             target_z = 0.5 * (zgrid(k,iCell) + zgrid(k+1,iCell))
             relhum(k,iCell) = vertical_interp(target_z, nfglevels_actual-1, &
                                        sorted_arr(:,1:nfglevels_actual-1), order=1, extrap=0)
+            if (target_z < z_fg(1,iCell) .and. k < nVertLevels) relhum(k,iCell) = relhum(k+1,iCell)
          end do
 
 
@@ -8378,6 +8379,7 @@ call mpas_log_write('Done with soil consistency check')
             target_z = 0.5 * (zgrid(k,iCell) + zgrid(k+1,iCell))
             spechum(k,iCell) = vertical_interp(target_z, nfglevels_actual-1, &
                                         sorted_arr(:,1:nfglevels_actual-1), order=1, extrap=0)
+            if (target_z < z_fg(1,iCell) .and. k < nVertLevels) spechum(k,iCell) = spechum(k+1,iCell)
          end do
 
         ! vertical interpolation of hydrometeors

--- a/src/core_landice/Registry.xml
+++ b/src/core_landice/Registry.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<registry model="mpas" core="landice" core_abbrev="li" version="8.3.1">
+<registry model="mpas" core="landice" core_abbrev="li" version="8.3.0">
 
 
 <!-- ======================================================================= -->

--- a/src/core_ocean/Registry.xml
+++ b/src/core_ocean/Registry.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<registry model="mpas" core="ocean" core_abbrev="ocn" version="8.3.1">
+<registry model="mpas" core="ocean" core_abbrev="ocn" version="8.3.0">
 
 	<dims>
 		<dim name="nCells" units="unitless"

--- a/src/core_seaice/Registry.xml
+++ b/src/core_seaice/Registry.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<registry model="mpas" core="seaice" core_abbrev="seaice" version="8.3.1">
+<registry model="mpas" core="seaice" core_abbrev="seaice" version="8.3.0">
 
 	<dims>
 		<dim name="nCells"

--- a/src/core_sw/Registry.xml
+++ b/src/core_sw/Registry.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<registry model="mpas" core="sw" core_abbrev="sw" version="8.3.1">
+<registry model="mpas" core="sw" core_abbrev="sw" version="8.3.0">
 	<dims>
 		<dim name="nCells"/>
 		<dim name="nEdges"/>

--- a/src/core_test/Registry.xml
+++ b/src/core_test/Registry.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<registry model="mpas" core="test" core_abbrev="test" version="8.3.1">
+<registry model="mpas" core="test" core_abbrev="test" version="8.3.0">
 	<dims>
 		<dim name="nCells"/>
 		<dim name="nEdges"/>


### PR DESCRIPTION
TYPE: new feature

KEYWORDS: clean sky diagnostic

SOURCES: Minsu Choi (CIRES/NOAA GSL) based on Douglas Lowe's (University of Manchester) original source code in WRF-Chem

DESCRIPTION OF CHANGES:

1. diagnostic variables are defined in "src/core_atmosphere/Registry.xml"
    !!Adding new variables for output: swdntcln, swupbcln;etc (using "cln" for clean sky variables)
    !!"config_calc_clean_atm_diag" is added in the Registry.xml as a physics namelist option (logical)
2. List of updated source code in src/core_atmosphere/physics
    !! mpas_atmphys_vars.F -> short/longwave clean sky diagnostics are added
    !! mpas_atmphys_update.F -> clean-sky variables are added for both short/longwave
    !! mpas_atmphys_init.F -> initializing corresponding variables
    !! mpas_atmphys_driver_radiation_sw.F -> where it call rrtmg_swrad in physics_wrf/module_ra_rrtmg_sw.F, short/longwave clean diagnostics are added with namelist variable. 
    !! mpas_atmphys_driver_radiation_lw.F -> logic follow "mpas_atmphys_driver_radiation_sw.F"
    !! mpas_atmphys_manager.F -> namelist option added
3. src/core_atmosphere/physics/physics_wrf/ radiation code updated. 
    !! code use "config_calc_clean_atm_diag". 
    !! module_ra_rrtmg_sw.F -> clean-sky diagnostics calculations are added.
    !! module_ra_rrtmg_lw.F -> clean-sky diagnostics calculations are added.

List of modified files:
!!src/core_atmosphere
Registry.xml

!!src/core_atmosphere/physics
mpas_atmphys_vars.F
mpas_atmphys_update.F
mpas_atmphys_init.F
mpas_atmphys_driver_radiation_sw.F
mpas_atmphys_driver_radiation_lw.F
mpas_atmphys_manager.F

!!src/core_atmosphere/physics/physics_wrf
module_ra_rrtmg_sw.F
module_ra_rrtmg_sw.F